### PR TITLE
feat: validate required environment variables in CLI

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -14,6 +14,7 @@ import {
   ReportFormat,
 } from './types';
 import { setLogLevel, LogLevel } from './utils/logger';
+import { validateRequiredOptions } from './utils/validation';
 
 dotenv.config();
 
@@ -30,7 +31,7 @@ program
   .description('Process batch payments from CSV, JSON, XLSX, or SWIFT MT103 files')
   .requiredOption('-i, --input <file>', 'Input file path (CSV, JSON, XLSX, or MT103)')
   .option('-f, --format <format>', 'Input format: csv, json, xlsx, mt103 (auto-detected from extension)')
-  .requiredOption('-s, --source-secret <key>', 'Source account secret key', process.env.ADMIN_SECRET_KEY)
+  .option('-s, --source-secret <key>', 'Source account secret key (or ADMIN_SECRET_KEY)')
   .option('-n, --network <network>', 'Network: testnet, mainnet, futurenet', 'testnet')
   .option('--horizon-url <url>', 'Horizon URL', process.env.HORIZON_URL || 'https://horizon-testnet.stellar.org')
   .option('--network-passphrase <passphrase>', 'Network passphrase (auto-detected from network)')
@@ -40,15 +41,22 @@ program
   .option('--concurrency <number>', 'Number of concurrent transaction submissions', '5')
   .option('--fee-surge-threshold <number>', 'Fee surge threshold in stroops (pauses if exceeded)', '100')
   .option('--rate-lock-minutes <number>', 'Rate lock window in minutes', '10')
-  .option('--escrow-contract <address>', 'Escrow contract address', process.env.ESCROW_CONTRACT_ADDRESS)
-  .option('--rate-oracle-contract <address>', 'Rate oracle contract address', process.env.RATE_ORACLE_CONTRACT_ADDRESS)
-  .option('--compliance-contract <address>', 'Compliance contract address', process.env.COMPLIANCE_CONTRACT_ADDRESS)
+  .option('--escrow-contract <address>', 'Escrow contract address (or ESCROW_CONTRACT_ADDRESS)')
+  .option('--rate-oracle-contract <address>', 'Rate oracle contract address (or RATE_ORACLE_CONTRACT_ADDRESS)')
+  .option('--compliance-contract <address>', 'Compliance contract address (or COMPLIANCE_CONTRACT_ADDRESS)')
   .option('--db-path <path>', 'SQLite database path for crash recovery', './stellar-payout.db')
   .option('--verbose', 'Enable verbose logging', false)
   .action(async (opts) => {
     if (opts.verbose) {
       setLogLevel(LogLevel.DEBUG);
     }
+
+    validateRequiredOptions(opts, process.env, [
+      { key: 'sourceSecret', envKey: 'ADMIN_SECRET_KEY', description: 'Source account secret key', optName: '--source-secret' },
+      { key: 'escrowContract', envKey: 'ESCROW_CONTRACT_ADDRESS', description: 'Escrow contract address', optName: '--escrow-contract' },
+      { key: 'rateOracleContract', envKey: 'RATE_ORACLE_CONTRACT_ADDRESS', description: 'Rate oracle contract address', optName: '--rate-oracle-contract' },
+      { key: 'complianceContract', envKey: 'COMPLIANCE_CONTRACT_ADDRESS', description: 'Compliance contract address', optName: '--compliance-contract' },
+    ]);
 
     const format = opts.format
       ? (opts.format as InputFormat)
@@ -101,7 +109,7 @@ program
   .command('retry')
   .description('Automatically resubmit failed transactions with exponential backoff')
   .requiredOption('-b, --batch-id <id>', 'Batch ID to retry failed entries')
-  .requiredOption('-s, --source-secret <key>', 'Source account secret key', process.env.ADMIN_SECRET_KEY)
+  .option('-s, --source-secret <key>', 'Source account secret key (or ADMIN_SECRET_KEY)')
   .option('--max-retries <number>', 'Maximum retry attempts per entry', '3')
   .option('--backoff-base <ms>', 'Base backoff delay in milliseconds', '1000')
   .option('--backoff-max <ms>', 'Maximum backoff delay in milliseconds', '30000')
@@ -113,6 +121,10 @@ program
     if (opts.verbose) {
       setLogLevel(LogLevel.DEBUG);
     }
+
+    validateRequiredOptions(opts, process.env, [
+      { key: 'sourceSecret', envKey: 'ADMIN_SECRET_KEY', description: 'Source account secret key', optName: '--source-secret' },
+    ]);
 
     await executeRetry({
       batchId: opts.batchId,

--- a/cli/src/utils/validation.ts
+++ b/cli/src/utils/validation.ts
@@ -3,6 +3,32 @@ import { StrKey } from 'stellar-sdk';
 import { PaymentRecord, ValidationResult } from '../types';
 import * as logger from './logger';
 
+export interface RequiredOption {
+  key: string;
+  envKey: string;
+  description: string;
+  optName: string;
+}
+
+export function validateRequiredOptions(
+  opts: any,
+  env: NodeJS.ProcessEnv,
+  requiredOptions: RequiredOption[]
+): void {
+  for (const req of requiredOptions) {
+    const value = opts[req.key];
+    if (!value) {
+      const envValue = env[req.envKey];
+      if (envValue) {
+        opts[req.key] = envValue;
+        logger.warn(`Using ${req.envKey} from environment variables instead of explicit ${req.optName}`);
+      } else {
+        throw new Error(`Missing required configuration. Please provide the following via command line options or environment variables:\n- ${req.optName} (or ${req.envKey})`);
+      }
+    }
+  }
+}
+
 export function validateStellarAddress(address: string): boolean {
   try {
     return StrKey.isValidEd25519PublicKey(address);


### PR DESCRIPTION
Closes #26

---

# Summary
Validate that required environment variables such as ADMIN_SECRET_KEY, ESCROW_CONTRACT_ADDRESS, RATE_ORACLE_CONTRACT_ADDRESS, and COMPLIANCE_CONTRACT_ADDRESS are present before running the CLI.

## 🚨 Problem
Missing environment values can lead to runtime failures during batch execution or retry operations, causing unpredictable behavior and difficult-to-debug errors.

## ✅ Expected Behavior
- **Fail Fast**: The CLI should immediately exit with clear guidance when required configuration values are missing.
- **Fallback Warnings**: Provide warnings if the CLI is using default values from .env instead of explicit command-line options, to ensure users are aware of their configuration source.

## 🛠 Changes
- Added alidateRequiredOptions utility to cli/src/utils/validation.ts to handle centralized validation logic.
- Integrated validation into the atch command in cli/src/index.ts.
- Integrated validation into the etry command in cli/src/index.ts.
- Implemented fallback warning mechanism when environment variables are used as fallbacks for command-line options.

## 🧪 Verification
- [x] Verified that missing required options/env vars cause the CLI to exit with a clear error message.
- [x] Verified that using environment variables instead of command-line options triggers a warning.
