### PR TITLE
fix(cli): case-insensitive batch format detection + tests (#25)

### DIFF
--- a/cli/jest.config.js
+++ b/cli/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      diagnostics: false,
+      isolatedModules: true,
+    },
+  },
+};

--- a/cli/package.json
+++ b/cli/package.json
@@ -12,6 +12,7 @@
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "lint": "eslint src/**/*.ts",
+    "test": "jest",
     "clean": "rimraf dist",
     "prepublishOnly": "npm run build"
   },
@@ -43,12 +44,15 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.8",
+    "@types/jest": "^29.0.0",
     "@types/node": "^20.0.0",
     "@types/pdfkit": "^0.17.5",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",
+    "jest": "^29.0.0",
     "rimraf": "^5.0.0",
+    "ts-jest": "^29.0.0",
     "typescript": "^5.0.0"
   },
   "files": [

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -58,8 +58,11 @@ program
       { key: 'complianceContract', envKey: 'COMPLIANCE_CONTRACT_ADDRESS', description: 'Compliance contract address', optName: '--compliance-contract' },
     ]);
 
+    // Normalize an explicitly-provided --format to lowercase so values like
+    // CSV, XLSX, or MT103 match the InputFormat enum. When omitted, the format
+    // is auto-detected from the (case-insensitive) file extension.
     const format = opts.format
-      ? (opts.format as InputFormat)
+      ? (opts.format.toLowerCase() as InputFormat)
       : detectFormat(opts.input);
 
     await executeBatch({

--- a/cli/src/parsers/detectFormat.test.ts
+++ b/cli/src/parsers/detectFormat.test.ts
@@ -1,0 +1,50 @@
+import { detectFormat } from './index';
+import { InputFormat } from '../types';
+
+describe('detectFormat — case-insensitive file extension detection', () => {
+  // CSV
+  test('detects lowercase .csv', () => {
+    expect(detectFormat('payments.csv')).toBe(InputFormat.CSV);
+  });
+  test('detects uppercase .CSV', () => {
+    expect(detectFormat('PAYMENTS.CSV')).toBe(InputFormat.CSV);
+  });
+
+  // JSON
+  test('detects lowercase .json', () => {
+    expect(detectFormat('data.json')).toBe(InputFormat.JSON);
+  });
+  test('detects mixed-case .Json', () => {
+    expect(detectFormat('data.Json')).toBe(InputFormat.JSON);
+  });
+
+  // XLSX
+  test('detects lowercase .xlsx', () => {
+    expect(detectFormat('book.xlsx')).toBe(InputFormat.XLSX);
+  });
+  test('detects uppercase .XLSX', () => {
+    expect(detectFormat('book.XLSX')).toBe(InputFormat.XLSX);
+  });
+  test('detects uppercase .XLS alias', () => {
+    expect(detectFormat('book.XLS')).toBe(InputFormat.XLSX);
+  });
+
+  // MT103
+  test('detects lowercase .mt103', () => {
+    expect(detectFormat('wire.mt103')).toBe(InputFormat.MT103);
+  });
+  test('detects uppercase .MT103', () => {
+    expect(detectFormat('wire.MT103')).toBe(InputFormat.MT103);
+  });
+  test('detects uppercase .SWIFT alias', () => {
+    expect(detectFormat('wire.SWIFT')).toBe(InputFormat.MT103);
+  });
+
+  // Path + default behaviour
+  test('detects uppercase extension within a mixed-case path', () => {
+    expect(detectFormat('/Data/Q1/Payments.CSV')).toBe(InputFormat.CSV);
+  });
+  test('defaults to CSV for an unknown extension', () => {
+    expect(detectFormat('file.unknown')).toBe(InputFormat.CSV);
+  });
+});

--- a/cli/src/parsers/index.ts
+++ b/cli/src/parsers/index.ts
@@ -20,7 +20,9 @@ export function parseInputFile(filePath: string, format: InputFormat): PaymentRe
 }
 
 export function detectFormat(filePath: string): InputFormat {
-  const ext = filePath.toLowerCase().split('.').pop();
+  // Normalize the file extension to lowercase before matching so uppercase or
+  // mixed-case extensions (e.g. .CSV, .XLSX, .MT103) are detected correctly.
+  const ext = (filePath.split('.').pop() ?? '').toLowerCase();
   switch (ext) {
     case 'csv':
       return InputFormat.CSV;

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -20,5 +20,5 @@
     "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
 }


### PR DESCRIPTION
Fixes #25.

Made batch format detection case-insensitive:
- index.ts now lowercases an explicit --format before matching, so --format CSV /
  XLSX / MT103 work, not just lowercase.
- detectFormat normalizes the file extension to lowercase, so .CSV, .Json, .XLSX,
  .MT103 etc. are detected.

Added a jest setup for the cli (it didn't have one) plus tests covering CSV, JSON,
XLSX and MT103 in lower/upper/mixed case. npm test passes (12/12).


