### PR TITLE
feat(cli): add --max-total-retry-time duration limit to retry (#28)

### DIFF
--- a/cli/jest.config.js
+++ b/cli/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      diagnostics: false,
+      isolatedModules: true,
+    },
+  },
+};

--- a/cli/package.json
+++ b/cli/package.json
@@ -12,6 +12,7 @@
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "lint": "eslint src/**/*.ts",
+    "test": "jest",
     "clean": "rimraf dist",
     "prepublishOnly": "npm run build"
   },
@@ -43,12 +44,15 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.8",
+    "@types/jest": "^29.0.0",
     "@types/node": "^20.0.0",
     "@types/pdfkit": "^0.17.5",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",
+    "jest": "^29.0.0",
     "rimraf": "^5.0.0",
+    "ts-jest": "^29.0.0",
     "typescript": "^5.0.0"
   },
   "files": [

--- a/cli/src/commands/retry.ts
+++ b/cli/src/commands/retry.ts
@@ -10,6 +10,7 @@ import axios from 'axios';
 import { RetryOptions, BatchEntryStatus, BatchStatus, BatchPaymentEntry } from '../types';
 import { BatchDatabase } from '../utils/database';
 import * as logger from '../utils/logger';
+import { isRetryTimeBudgetExhausted } from '../utils/retry-budget';
 
 export async function executeRetry(options: RetryOptions): Promise<void> {
   const db = new BatchDatabase(options.dbPath);
@@ -33,13 +34,26 @@ export async function executeRetry(options: RetryOptions): Promise<void> {
   logger.info(`Found ${failedEntries.length} failed entries to retry`);
   logger.info(`Max retries per entry: ${options.maxRetries}`);
   logger.info(`Backoff base: ${options.backoffBase}ms`);
+  if (options.maxTotalRetryTime > 0) {
+    logger.info(`Max total retry time: ${options.maxTotalRetryTime}ms`);
+  }
 
   const sourceKeypair = Keypair.fromSecret(options.sourceSecret);
+  const retryStart = Date.now();
   let retried = 0;
   let succeeded = 0;
   let permanentlyFailed = 0;
 
   for (const entry of failedEntries) {
+    // Stop the loop once the total retry time budget is used up, even if
+    // attempts remain. This bounds how long retries run during outages.
+    if (isRetryTimeBudgetExhausted(Date.now() - retryStart, options.maxTotalRetryTime)) {
+      logger.warn(
+        `Max total retry time (${options.maxTotalRetryTime}ms) reached. Stopping with remaining entries left for a later run.`
+      );
+      break;
+    }
+
     if (entry.retryCount >= options.maxRetries) {
       logger.warn(`Entry #${entry.index}: Max retries (${options.maxRetries}) exceeded. Skipping.`);
       db.updateEntryStatus(options.batchId, entry.index, BatchEntryStatus.Skipped);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -113,6 +113,7 @@ program
   .option('--max-retries <number>', 'Maximum retry attempts per entry', '3')
   .option('--backoff-base <ms>', 'Base backoff delay in milliseconds', '1000')
   .option('--backoff-max <ms>', 'Maximum backoff delay in milliseconds', '30000')
+  .option('--max-total-retry-time <ms>', 'Total retry time budget in milliseconds; retries stop once this duration is reached even if attempts remain (0 = no time limit)', '0')
   .option('--horizon-url <url>', 'Horizon URL', process.env.HORIZON_URL || 'https://horizon-testnet.stellar.org')
   .option('--network-passphrase <passphrase>', 'Network passphrase', process.env.NETWORK_PASSPHRASE || 'Test SDF Network ; September 2015')
   .option('--db-path <path>', 'SQLite database path', './stellar-payout.db')
@@ -131,6 +132,7 @@ program
       maxRetries: parseInt(opts.maxRetries, 10),
       backoffBase: parseInt(opts.backoffBase, 10),
       backoffMax: parseInt(opts.backoffMax, 10),
+      maxTotalRetryTime: parseInt(opts.maxTotalRetryTime, 10),
       dbPath: opts.dbPath,
       sourceSecret: opts.sourceSecret,
       horizonUrl: opts.horizonUrl,

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -110,6 +110,8 @@ export interface RetryOptions {
   maxRetries: number;
   backoffBase: number;
   backoffMax: number;
+  /** Total retry time budget in milliseconds (0 = no time limit). */
+  maxTotalRetryTime: number;
   dbPath: string;
   sourceSecret: string;
   horizonUrl: string;

--- a/cli/src/utils/retry-budget.test.ts
+++ b/cli/src/utils/retry-budget.test.ts
@@ -1,0 +1,42 @@
+import { isRetryTimeBudgetExhausted } from './retry-budget';
+
+describe('isRetryTimeBudgetExhausted', () => {
+  test('no time limit (0) is never exhausted, even after a long time', () => {
+    expect(isRetryTimeBudgetExhausted(0, 0)).toBe(false);
+    expect(isRetryTimeBudgetExhausted(10_000_000, 0)).toBe(false);
+  });
+
+  test('a negative budget is treated as no limit', () => {
+    expect(isRetryTimeBudgetExhausted(5_000, -1)).toBe(false);
+  });
+
+  test('not exhausted while elapsed is below the budget', () => {
+    expect(isRetryTimeBudgetExhausted(4_999, 5_000)).toBe(false);
+  });
+
+  test('exhausted exactly at the budget', () => {
+    expect(isRetryTimeBudgetExhausted(5_000, 5_000)).toBe(true);
+  });
+
+  test('exhausted once elapsed exceeds the budget', () => {
+    expect(isRetryTimeBudgetExhausted(7_500, 5_000)).toBe(true);
+  });
+
+  test('stops on whichever limit is reached first (duration before attempts)', () => {
+    // Simulate a loop that would run more attempts but is capped by duration.
+    const budgetMs = 1_000;
+    const elapsedPerAttempt = 400;
+    let attempts = 0;
+    const maxAttempts = 10;
+    let elapsed = 0;
+    while (
+      attempts < maxAttempts &&
+      !isRetryTimeBudgetExhausted(elapsed, budgetMs)
+    ) {
+      attempts += 1;
+      elapsed += elapsedPerAttempt;
+    }
+    // 0ms ok, 400ms ok, 800ms ok, 1200ms exhausted -> 3 attempts ran.
+    expect(attempts).toBe(3);
+  });
+});

--- a/cli/src/utils/retry-budget.ts
+++ b/cli/src/utils/retry-budget.ts
@@ -1,0 +1,19 @@
+/**
+ * Decide whether the retry loop should stop because the total time budget has
+ * been used up.
+ *
+ * The retry command stops when *either* the per-entry attempt cap or this total
+ * duration limit is reached. A `maxTotalRetryTime` of 0 (or negative) means
+ * "no time limit" — only the attempt cap applies, preserving the original
+ * behaviour. Otherwise retries stop once the elapsed wall-clock time reaches the
+ * budget, even if attempts remain (useful during long network outages).
+ *
+ * @param elapsedMs         milliseconds elapsed since retrying started
+ * @param maxTotalRetryTime total retry time budget in milliseconds (0 = unlimited)
+ */
+export function isRetryTimeBudgetExhausted(
+  elapsedMs: number,
+  maxTotalRetryTime: number
+): boolean {
+  return maxTotalRetryTime > 0 && elapsedMs >= maxTotalRetryTime;
+}

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -20,5 +20,5 @@
     "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
 }


### PR DESCRIPTION
Fixes #28.

Adds a --max-total-retry-time option to the retry command so retries can be
bounded by total wall-clock duration, not just attempt count. The loop now stops
when either limit is reached first, which avoids retries dragging on through a
long network outage. Default is 0 (no time limit), so existing behavior is
unchanged unless you opt in.

Pulled the decision into a small isRetryTimeBudgetExhausted helper and tested it
(npm test, 6/6). The option's help text documents the behavior.

