### PR TITLE
feat: atomic batch resume, MT103 field parsing, monorepo build and deployment docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [main, master]
 
 jobs:
+  # ── Rust Soroban contracts ──────────────────────────────────────────────────
   rust:
     name: Rust Build & Test
     runs-on: ubuntu-latest
@@ -28,13 +29,14 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Build contracts
-        run: cargo build --release --target wasm32-unknown-unknown
+        run: npm run build:contracts
 
       - name: Run contract tests
-        run: cargo test
+        run: npm run test:contracts
 
+  # ── TypeScript packages ─────────────────────────────────────────────────────
   typescript:
-    name: TypeScript Lint, Test & Build
+    name: TypeScript Lint, Type-Check, Test & Build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -53,31 +55,26 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install dependencies (SDK)
-        working-directory: ./sdk
-        run: npm ci
+      - name: Install workspace dependencies
+        run: npm install --workspaces --include-workspace-root
 
-      - name: Install dependencies (CLI)
-        working-directory: ./cli
-        run: npm ci
+      - name: Type-check all packages
+        run: npm run type-check
 
-      - name: Install dependencies (UI)
-        working-directory: ./ui
-        run: npm ci
+      - name: Lint all packages
+        run: npm run lint
 
-      - name: Lint
-        run: |
-          cd sdk && npm run lint
-          cd ../cli && npm run lint
-          cd ../ui && npm run lint
+      - name: Test SDK
+        run: npm run test:sdk
 
-      - name: Test
-        run: |
-          cd sdk && npm test
-          cd ../cli && npm test
+      - name: Test CLI
+        run: npm run test:cli
 
-      - name: Build
-        run: |
-          cd sdk && npm run build
-          cd ../cli && npm run build
-          cd ../ui && npm run build
+      - name: Build SDK
+        run: npm run build:sdk
+
+      - name: Build CLI
+        run: npm run build:cli
+
+      - name: Build UI
+        run: npm run build:ui

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A comprehensive SDK for building cross-border payment applications on the Stella
 - [Examples](#examples)
 - [Configuration](#configuration)
 - [API Reference](#api-reference)
+- [Building](#building)
 - [Testing](#testing)
 - [Deployment](#deployment)
 - [Contributing](#contributing)
@@ -36,8 +37,8 @@ A comprehensive SDK for building cross-border payment applications on the Stella
 
 ### Prerequisites
 - Node.js 18+ 
-- Rust 1.70+ (for contract compilation)
-- Soroban CLI (for contract deployment)
+- Rust 1.78+ (for contract compilation)
+- Stellar CLI 21+ (for contract deployment)
 
 ### Install SDK
 
@@ -46,22 +47,18 @@ A comprehensive SDK for building cross-border payment applications on the Stella
 git clone https://github.com/stellar-cross-border/stellar-cross-border-payments-sdk.git
 cd stellar-cross-border-payments-sdk
 
-# Install dependencies
+# Install all workspace dependencies (sdk + cli + ui) in one step
 npm install
 
-# Install Rust dependencies
-cd src && cargo build
-cd ..
+# Install Rust wasm target
+rustup target add wasm32-unknown-unknown
 ```
 
 ### Environment Setup
 
 ```bash
-# Copy environment template
 cp .env.example .env
-
-# Edit with your configuration
-nano .env
+# Edit .env with your contract addresses and keys — see docs/deployment.md
 ```
 
 ## ⚡ Quick Start
@@ -544,6 +541,50 @@ GCFONE23AB...,1200.00,EURC,payroll-002,86400
 - **Multi-Format Input**: CSV, JSON, Excel (.xlsx), SWIFT MT103
 - **Compliance Reports**: PDF and CSV audit trail generation
 
+### Crash Recovery & Resume
+
+The CLI persists all batch state to a local SQLite database (default: `./stellar-payout.db`).
+Atomicity guarantees ensure the database is never left in a half-written state:
+
+| Operation | Atomicity guarantee |
+|---|---|
+| Batch initialisation | `initBatch()` creates the row **and** sets status `running` in one transaction — no stuck `created` batches |
+| Entry seeding | All payment-entry rows inserted in one transaction — either all exist or none do |
+| Group confirmation | Group row + every entry row set to `confirmed` together — a crash after Horizon confirms but before the write completes leaves entries in `submitted`, not a false `confirmed` |
+| Group failure | Group row + every entry row set to `failed` together |
+| Graceful pause | `SIGINT`/`SIGTERM` atomically sets status `paused` and refreshes all counters |
+
+#### Detecting and resuming stale batches
+
+A batch in `running` or `paused` status at startup indicates an interrupted run:
+
+```ts
+const stale = db.getBatchesNeedingResume();
+// Returns both 'paused' (graceful SIGINT) and 'running' (hard crash) batches
+```
+
+To resume:
+
+```ts
+db.resumeBatch(batchId);                           // status → running, counters refreshed
+const groups = db.getIncompleteGroups(batchId);    // groups not yet confirmed
+for (const group of groups) {
+  const pending = db.getPendingEntriesByGroup(batchId, group.groupIndex);
+  // re-submit pending / submitted entries only — confirmed entries are skipped
+}
+```
+
+From the CLI, resume failed entries with:
+
+```bash
+stellar-payout retry --batch-id <id> --source-secret $SECRET_KEY
+```
+
+The `retry` command re-submits every entry whose status is `failed`.
+For entries stuck in `submitted` (submitted to Horizon but not yet confirmed),
+re-running the batch command with the same `--db-path` will detect the incomplete
+groups via `getIncompleteGroups` and re-check Horizon for their status.
+
 ## ⚙️ Configuration
 
 ### Environment Variables
@@ -564,21 +605,7 @@ ADMIN_SECRET_KEY=YOUR_ADMIN_SECRET_KEY
 ADMIN_PUBLIC_KEY=YOUR_ADMIN_PUBLIC_KEY
 ```
 
-### Contract Deployment
-
-```bash
-# Build contracts
-cd src
-cargo build --target wasm32-unknown-unknown --release
-
-# Deploy escrow contract
-soroban contract deploy \
-  --wasm target/wasm32-unknown-unknown/release/stellar_cross_border_payments_sdk.wasm \
-  --source ADMIN_SECRET_KEY \
-  --network testnet
-
-# Deploy other contracts similarly
-```
+See [docs/deployment.md](docs/deployment.md) for the full list of environment variables and their defaults.
 
 ## 📖 API Reference
 
@@ -637,32 +664,34 @@ interface ComplianceCheckResult extends TransactionResult {
 
 ## 🧪 Testing
 
-### Run Contract Tests
+### Run contract tests
 
 ```bash
-cd src
 cargo test
+# or via root script
+npm run test:contracts
 ```
 
-### Run SDK Tests
+### Run SDK tests
 
 ```bash
-cd sdk
+npm run test:sdk
+# or directly
+cd sdk && npm test
+```
+
+### Run CLI tests
+
+```bash
+npm run test:cli
+# or directly
+cd cli && npm test
+```
+
+### Run all tests
+
+```bash
 npm test
-```
-
-### Run UI Tests
-
-```bash
-cd ui
-npm test
-```
-
-### Integration Tests
-
-```bash
-# Run all examples as tests
-npm run test:examples
 ```
 
 ## Type Safety & Validation
@@ -686,92 +715,124 @@ Metadata must be flat key-value with primitive values only.
 
 ## 🚀 Deployment
 
-### Deploy to Testnet
+See **[docs/deployment.md](docs/deployment.md)** for the complete guide, including:
+
+- Compiling the Soroban contracts to WASM
+- Deploying to testnet and mainnet with Stellar CLI
+- Initialising contract state (admin, restricted jurisdictions, rate sources, compliance records)
+- Wiring contract addresses into the SDK and CLI
+- Example testnet addresses for quick testing
+- Troubleshooting common errors
+
+Quick-start (testnet):
 
 ```bash
-# 1. Deploy contracts
-npm run deploy:testnet
+# 1. Compile contracts
+npm run build:contracts
 
-# 2. Update environment variables
-cp .env.example .env.testnet
-# Edit with testnet contract addresses
+# 2. Generate and fund an admin keypair
+stellar keys generate admin --network testnet
+stellar keys fund admin --network testnet
 
-# 3. Deploy UI
-cd ui
+# 3. Deploy all three contracts
+WASM=target/wasm32-unknown-unknown/release/stellar_cross_border_payments_sdk.wasm
+ESCROW=$(stellar contract deploy --wasm "$WASM" --source admin --network testnet)
+ORACLE=$(stellar contract deploy --wasm "$WASM" --source admin --network testnet)
+COMPLIANCE=$(stellar contract deploy --wasm "$WASM" --source admin --network testnet)
+
+# 4. Write addresses to .env
+echo "ESCROW_CONTRACT_ADDRESS=$ESCROW"        >> .env
+echo "RATE_ORACLE_CONTRACT_ADDRESS=$ORACLE"   >> .env
+echo "COMPLIANCE_CONTRACT_ADDRESS=$COMPLIANCE" >> .env
+
+# 5. Build TypeScript packages
 npm run build
-npm run start
-```
 
-### Deploy to Mainnet
-
-```bash
-# 1. Deploy contracts to mainnet
-npm run deploy:mainnet
-
-# 2. Update production environment
-cp .env.example .env.production
-# Edit with mainnet contract addresses
-
-# 3. Deploy UI to production
-cd ui
-npm run build
-npm run start:prod
+# 6. Run a test batch payment
+stellar-payout batch --input examples/payroll-batch.csv \
+  --source-secret "$ADMIN_SECRET_KEY" --network testnet --dry-run
 ```
 
 ## 🔧 Development
 
-### Build Contracts
+### Watch mode
 
 ```bash
-cd src
-cargo build --target wasm32-unknown-unknown --release
+npm run dev:sdk   # tsc --watch in sdk/
+npm run dev:cli   # tsc --watch in cli/
+npm run dev:ui    # next dev in ui/
 ```
 
-### Build SDK
+### Code style
+
+- Rust: `cargo fmt` and `cargo clippy`
+- TypeScript: ESLint (`npm run lint`) and Prettier
+- React: Follow React best practices
+
+## 🏗 Building
+
+The repo uses npm workspaces. All packages can be built from the root.
+
+### Build all packages
 
 ```bash
-cd sdk
-npm run build
+# Full build: Rust contracts → SDK → CLI → UI
+npm run build:full
+
+# Or build each layer separately
+npm run build:contracts   # cargo build --release --target wasm32-unknown-unknown
+npm run build:sdk         # tsc in sdk/
+npm run build:cli         # tsc in cli/
+npm run build:ui          # next build in ui/
 ```
 
-### Build UI
+### Build scripts (with output summaries)
 
 ```bash
-cd ui
-npm run build
+# Linux / macOS / CI
+./scripts/build.sh
+
+# Windows PowerShell
+.\scripts\build.ps1
+
+# Type-check only (no emit)
+./scripts/build.sh --type-check
+.\scripts\build.ps1 -TypeCheck
+
+# Skip contracts, only build TypeScript
+./scripts/build.sh --ts-only
 ```
 
-### Local Development
+### Build order
+
+The three TypeScript packages must be built in this order:
+
+1. **`sdk/`** — compiled first because the CLI workspace resolves the SDK from `sdk/dist`.
+2. **`cli/`** — depends on `sdk/dist` being present.
+3. **`ui/`** — Next.js build, independent of cli and sdk dist (uses workspace package resolution).
+
+The Rust contracts must be compiled before deploying, but the TypeScript
+packages do not depend on the WASM artefacts at compile time.  Contract
+addresses are supplied at runtime via environment variables.
+
+### Type-check without building
 
 ```bash
-# Start local Soroban RPC
-soroban rpc start
-
-# Run contracts in local mode
-npm run dev:local
-
-# Start UI development server
-cd ui
-npm run dev
+npm run type-check          # all packages
+npm run type-check:sdk
+npm run type-check:cli
+npm run type-check:ui
 ```
 
 ## 🤝 Contributing
 
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
 
-### Development Workflow
-
 1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Add tests
+2. Create a feature branch (`git checkout -b feat/my-change`)
+3. Make your changes and add tests
+4. Run the full build and test suite: `npm run build:full && npm test && cargo test`
 5. Submit a pull request
-
-### Code Style
-
-- Rust: Use `rustfmt` and `clippy`
-- TypeScript: Use ESLint and Prettier
-- React: Follow React best practices
 
 ## 📄 License
 

--- a/cli/jest.config.js
+++ b/cli/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      diagnostics: false,
+      isolatedModules: true,
+    },
+  },
+};

--- a/cli/package.json
+++ b/cli/package.json
@@ -11,6 +11,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
+    "test": "jest --runInBand",
     "lint": "eslint src/**/*.ts",
     "clean": "rimraf dist",
     "prepublishOnly": "npm run build"
@@ -43,12 +44,15 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.8",
+    "@types/jest": "^29.0.0",
     "@types/node": "^20.0.0",
     "@types/pdfkit": "^0.17.5",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",
+    "jest": "^29.0.0",
     "rimraf": "^5.0.0",
+    "ts-jest": "^29.0.0",
     "typescript": "^5.0.0"
   },
   "files": [

--- a/cli/src/commands/batch.ts
+++ b/cli/src/commands/batch.ts
@@ -120,8 +120,10 @@ function setupSignalHandlers(): void {
 
     if (currentDb && currentBatchId) {
       logger.info('Saving batch state for crash recovery...');
-      currentDb.updateBatchStatus(currentBatchId, BatchStatus.Paused);
-      currentDb.updateBatchCounters(currentBatchId);
+      // markBatchPaused is a single atomic SQLite transaction — status + counters
+      // are written together so a secondary crash during shutdown cannot produce
+      // a batch row whose counters don't match its entry rows.
+      currentDb.markBatchPaused(currentBatchId);
       logger.success('Batch state saved. You can resume with: stellar-payout retry --batch-id=' + currentBatchId);
     }
 
@@ -211,9 +213,10 @@ export async function executeBatch(config: BatchConfig): Promise<void> {
   const sourcePublicKey = sourceKeypair.publicKey();
   logger.info(`Source account: ${sourcePublicKey}`);
 
-  // Create batch in database
-  db.createBatch(batchId, valid.length, sourcePublicKey, config.network, config.dryRun);
-  db.updateBatchStatus(batchId, BatchStatus.Running);
+  // Create batch in database — atomically creates the row and sets status to
+  // 'running' in one transaction, eliminating the crash window between
+  // creation and activation.
+  db.initBatch(batchId, valid.length, sourcePublicKey, config.network, config.dryRun);
 
   // Group payments into batches of maxOpsPerTx
   const groups = groupPayments(valid, config.maxOpsPerTx);
@@ -400,12 +403,10 @@ async function processGroup(
       logger.info(`[DRY RUN] Group ${groupIdx}: ${records.length} operations simulated`);
       txGroup.txHash = `dryrun_${crypto.randomBytes(16).toString('hex')}`;
       txGroup.status = BatchEntryStatus.Confirmed;
-      db.insertGroup(batchId, txGroup);
+      db.upsertGroup(batchId, txGroup);
 
-      for (const record of records) {
-        const entryIdx = records.indexOf(record) + groupIdx * config.maxOpsPerTx;
-        db.updateEntryStatus(batchId, entryIdx, BatchEntryStatus.Confirmed, txGroup.txHash);
-      }
+      const entryIndices = records.map((_, i) => i + groupIdx * config.maxOpsPerTx);
+      db.confirmGroupWithEntries(batchId, groupIdx, txGroup.txHash, entryIndices);
       return;
     }
 
@@ -414,11 +415,15 @@ async function processGroup(
     const txXdr = transaction.toXDR();
 
     txGroup.submittedAt = Date.now();
-    db.insertGroup(batchId, txGroup);
+    // upsertGroup is idempotent — safe to call even if a previous run already
+    // inserted a row for this (batchId, groupIdx) pair.
+    db.upsertGroup(batchId, txGroup);
+
+    // Compute entry indices once — reused for atomic confirm / fail calls.
+    const entryIndices = records.map((_, i) => i + groupIdx * config.maxOpsPerTx);
 
     // Mark entries as submitted
-    for (let i = 0; i < records.length; i++) {
-      const entryIdx = i + groupIdx * config.maxOpsPerTx;
+    for (const entryIdx of entryIndices) {
       db.updateEntryStatus(batchId, entryIdx, BatchEntryStatus.Submitted);
     }
 
@@ -426,26 +431,13 @@ async function processGroup(
     const result = await submitWithRetry(txXdr, config.horizonUrl);
 
     if (result.successful) {
-      txGroup.txHash = result.hash;
-      txGroup.status = BatchEntryStatus.Confirmed;
-      txGroup.confirmedAt = Date.now();
-      db.updateGroupStatus(batchId, groupIdx, BatchEntryStatus.Confirmed, result.hash);
-
-      for (let i = 0; i < records.length; i++) {
-        const entryIdx = i + groupIdx * config.maxOpsPerTx;
-        db.updateEntryStatus(batchId, entryIdx, BatchEntryStatus.Confirmed, result.hash);
-      }
-
+      // Atomic: group row + every entry row confirmed together.
+      // A crash between these writes can no longer leave a partial state.
+      db.confirmGroupWithEntries(batchId, groupIdx, result.hash, entryIndices);
       logger.debug(`Group ${groupIdx}: Confirmed (${result.hash})`);
     } else {
-      txGroup.status = BatchEntryStatus.Failed;
-      db.updateGroupStatus(batchId, groupIdx, BatchEntryStatus.Failed);
-
-      for (let i = 0; i < records.length; i++) {
-        const entryIdx = i + groupIdx * config.maxOpsPerTx;
-        db.updateEntryStatus(batchId, entryIdx, BatchEntryStatus.Failed, '', result.error || 'Transaction failed');
-      }
-
+      // Atomic: group row + every entry row failed together.
+      db.failGroupWithEntries(batchId, groupIdx, result.error || 'Transaction failed', entryIndices);
       logger.warn(`Group ${groupIdx}: Failed - ${result.error || 'Unknown error'}`);
     }
   } catch (err) {
@@ -453,12 +445,10 @@ async function processGroup(
     logger.error(`Group ${groupIdx} error: ${errorMsg}`);
 
     txGroup.status = BatchEntryStatus.Failed;
-    db.insertGroup(batchId, txGroup);
+    db.upsertGroup(batchId, txGroup);
 
-    for (let i = 0; i < records.length; i++) {
-      const entryIdx = i + groupIdx * config.maxOpsPerTx;
-      db.updateEntryStatus(batchId, entryIdx, BatchEntryStatus.Failed, '', errorMsg);
-    }
+    const entryIndices = records.map((_, i) => i + groupIdx * config.maxOpsPerTx);
+    db.failGroupWithEntries(batchId, groupIdx, errorMsg, entryIndices);
   }
 }
 

--- a/cli/src/parsers/mt103-parser.test.ts
+++ b/cli/src/parsers/mt103-parser.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Tests for the SWIFT MT103 parser.
+ *
+ * We use `parseMT103` (file-based) via a helper that writes a temp file so the
+ * tests remain self-contained without requiring fixture files on disk.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { parseMT103 } from './mt103-parser';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Write content to a temp file and return its path. */
+function writeTempMT103(content: string): string {
+  const tmpFile = path.join(os.tmpdir(), `mt103-test-${Date.now()}-${Math.random().toString(36).slice(2)}.mt103`);
+  fs.writeFileSync(tmpFile, content, 'utf-8');
+  return tmpFile;
+}
+
+/** Parse an inline MT103 string without needing a real file. */
+function parseMT103String(content: string) {
+  const file = writeTempMT103(content);
+  try {
+    return parseMT103(file);
+  } finally {
+    fs.unlinkSync(file);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sample MT103 messages
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal valid MT103 with a Stellar address in field :59:.
+ *
+ * Field layout mirrors the real SWIFT Block 4 structure (content after `{4:`).
+ */
+const BASIC_MT103 = `{4:
+:20:REF20240101001
+:23B:CRED
+:32A:240101USD1500,00
+:50K:/123456789
+ACME Corp
+:52A:BANKUS33
+:57A:STELLARXX
+:59:/GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2
+John Beneficiary
+:70:/INV/2024-001
+:71A:OUR
+-}`;
+
+/**
+ * MT103 with a Stellar public key embedded in :59: but NOT on the first line
+ * (key is on the second line of the beneficiary field).
+ */
+const STELLAR_KEY_ON_SECOND_LINE = `{4:
+:20:REF20240101002
+:23B:CRED
+:32A:240115EUR2000,50
+:50K:SENDER NAME
+:57A:EUROBICXX
+:59:
+GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2
+Maria Recipient
+:70:/RFB/PO-9876
+:71A:SHA
+-}`;
+
+/**
+ * MT103 with field :59: containing only an IBAN-style account (no Stellar key).
+ */
+const IBAN_BENEFICIARY = `{4:
+:20:REF20240101003
+:23B:CRED
+:32A:240120GBP750,
+:50K:/UK29NWBK60161331926819
+British Sender Ltd
+:57A:NWBKGB2L
+:59:/DE89370400440532013000
+Hans Mueller
+:70:/RFB/INV-DE-2024
+:71A:OUR
+-}`;
+
+/**
+ * MT103 with multi-line :70: remittance information.
+ */
+const MULTILINE_REMITTANCE = `{4:
+:20:REF20240101004
+:23B:CRED
+:32A:240201MXN18000,
+:52A:BANAMEXMM
+:59:GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2
+:70:/RFB/PAYROLL-FEB-2024
+/EMPL/EMP-00042
+/DEPT/ENGINEERING
+:71A:OUR
+-}`;
+
+/**
+ * File containing two MT103 messages back-to-back.
+ */
+const TWO_MESSAGES = `{4:
+:20:REF-A
+:23B:CRED
+:32A:240301USD500,
+:59:GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2
+:70:/INV/AAA
+-}
+{4:
+:20:REF-B
+:23B:CRED
+:32A:240301EUR800,
+:59:GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL3
+:70:/INV/BBB
+-}`;
+
+/**
+ * Message with no amount — should be skipped by the parser.
+ */
+const MISSING_AMOUNT = `{4:
+:20:REF-NOAMT
+:23B:CRED
+:59:GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2
+:70:/RFB/TEST
+-}`;
+
+/**
+ * Message with no beneficiary — should be skipped by the parser.
+ */
+const MISSING_BENEFICIARY = `{4:
+:20:REF-NOBENEF
+:23B:CRED
+:32A:240301USD100,
+:70:/RFB/TEST
+-}`;
+
+// ---------------------------------------------------------------------------
+// Tests — field :32A: (Value Date / Currency / Amount)
+// ---------------------------------------------------------------------------
+
+describe('MT103 :32A: field parsing', () => {
+  it('parses currency from :32A:', () => {
+    const [record] = parseMT103String(BASIC_MT103);
+    // USD maps to USDC
+    expect(record.asset).toBe('USDC');
+  });
+
+  it('parses decimal amount (comma separator) from :32A:', () => {
+    const [record] = parseMT103String(BASIC_MT103);
+    expect(record.amount).toBe('1500.00');
+  });
+
+  it('parses EUR and maps to EURC', () => {
+    const [record] = parseMT103String(STELLAR_KEY_ON_SECOND_LINE);
+    expect(record.asset).toBe('EURC');
+    expect(record.amount).toBe('2000.50');
+  });
+
+  it('parses GBP and keeps it as GBP', () => {
+    const [record] = parseMT103String(IBAN_BENEFICIARY);
+    expect(record.asset).toBe('GBP');
+  });
+
+  it('parses MXN and keeps it as MXN', () => {
+    const [record] = parseMT103String(MULTILINE_REMITTANCE);
+    expect(record.asset).toBe('MXN');
+  });
+
+  it('handles whole-number amount with trailing comma', () => {
+    const [record] = parseMT103String(IBAN_BENEFICIARY);
+    // 750, → 750
+    expect(record.amount).toBe('750');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — field :59: (Beneficiary Customer)
+// ---------------------------------------------------------------------------
+
+describe('MT103 :59: beneficiary account parsing', () => {
+  it('extracts a Stellar public key from :59: on the same line as the tag', () => {
+    const [record] = parseMT103String(BASIC_MT103);
+    expect(record.destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+  });
+
+  it('extracts a Stellar public key from a continuation line in :59:', () => {
+    const [record] = parseMT103String(STELLAR_KEY_ON_SECOND_LINE);
+    expect(record.destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+  });
+
+  it('extracts Stellar key embedded directly in :59: without account prefix', () => {
+    const [record] = parseMT103String(MULTILINE_REMITTANCE);
+    expect(record.destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+  });
+
+  it('falls back to IBAN-style account when no Stellar key is present', () => {
+    const [record] = parseMT103String(IBAN_BENEFICIARY);
+    // The IBAN account should be used as the destination
+    expect(record.destination).toBe('DE89370400440532013000');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — field :70: (Remittance Information)
+// ---------------------------------------------------------------------------
+
+describe('MT103 :70: remittance / narrative parsing', () => {
+  it('uses :70: remittance info as the payment memo', () => {
+    const [record] = parseMT103String(BASIC_MT103);
+    expect(record.memo).toContain('INV/2024-001');
+  });
+
+  it('joins multi-line :70: remittance lines into a single string', () => {
+    const [record] = parseMT103String(MULTILINE_REMITTANCE);
+    // All three continuation lines should appear in the memo
+    expect(record.memo).toContain('RFB/PAYROLL-FEB-2024');
+    expect(record.memo).toContain('EMPL/EMP-00042');
+    expect(record.memo).toContain('DEPT/ENGINEERING');
+  });
+
+  it('strips leading slash from remittance continuation lines', () => {
+    const [record] = parseMT103String(MULTILINE_REMITTANCE);
+    // The raw lines start with / — after parsing they should not appear as //
+    expect(record.memo).not.toMatch(/\/\//);
+  });
+
+  it('falls back to :20: transaction reference when :70: is absent', () => {
+    // Construct a message without a :70: field
+    const noRemittance = `{4:
+:20:TX-REF-FALLBACK
+:23B:CRED
+:32A:240301USD100,
+:59:GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2
+:71A:OUR
+-}`;
+    const [record] = parseMT103String(noRemittance);
+    expect(record.memo).toBe('TX-REF-FALLBACK');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — multi-message files and edge cases
+// ---------------------------------------------------------------------------
+
+describe('MT103 multi-message files and edge cases', () => {
+  it('parses two messages from a single file', () => {
+    const records = parseMT103String(TWO_MESSAGES);
+    expect(records).toHaveLength(2);
+  });
+
+  it('assigns correct amounts to each message in a multi-message file', () => {
+    const records = parseMT103String(TWO_MESSAGES);
+    expect(records[0].amount).toBe('500');
+    expect(records[1].amount).toBe('800');
+  });
+
+  it('assigns correct assets to each message in a multi-message file', () => {
+    const records = parseMT103String(TWO_MESSAGES);
+    expect(records[0].asset).toBe('USDC'); // USD → USDC
+    expect(records[1].asset).toBe('EURC'); // EUR → EURC
+  });
+
+  it('skips messages that are missing an amount', () => {
+    const records = parseMT103String(MISSING_AMOUNT);
+    expect(records).toHaveLength(0);
+  });
+
+  it('skips messages that are missing a beneficiary', () => {
+    const records = parseMT103String(MISSING_BENEFICIARY);
+    expect(records).toHaveLength(0);
+  });
+
+  it('sets default escrow_duration to 86400 (24h) for all MT103 payments', () => {
+    const [record] = parseMT103String(BASIC_MT103);
+    expect(record.escrow_duration).toBe(86400);
+  });
+
+  it('returns empty array for a file with no valid MT103 blocks', () => {
+    const records = parseMT103String('This is not an MT103 file.\nRandom content.');
+    expect(records).toHaveLength(0);
+  });
+
+  it('maps unknown currency codes through as-is instead of defaulting to USDC', () => {
+    const unknownCurrency = `{4:
+:20:REF-UNK
+:23B:CRED
+:32A:240301XYZ200,
+:59:GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2
+:70:/RFB/TEST
+-}`;
+    const [record] = parseMT103String(unknownCurrency);
+    // Unknown currencies pass through rather than being silently coerced to USDC
+    expect(record.asset).toBe('XYZ');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — field :50K: (Ordering Customer)
+// ---------------------------------------------------------------------------
+
+describe('MT103 :50K: ordering customer parsing', () => {
+  it('captures the ordering customer account and name from :50K:', () => {
+    const [record] = parseMT103String(BASIC_MT103);
+    // We don't map orderingCustomer to PaymentRecord directly, but we can
+    // verify the file round-trips correctly by checking other fields are intact.
+    // The key assertion is that the presence of :50K: does not corrupt other fields.
+    expect(record.destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+    expect(record.amount).toBe('1500.00');
+  });
+
+  it('does not treat :50K: content as the beneficiary destination', () => {
+    // Sender /123456789 must not bleed into the destination field
+    const [record] = parseMT103String(BASIC_MT103);
+    expect(record.destination).not.toContain('123456789');
+  });
+});

--- a/cli/src/parsers/mt103-parser.ts
+++ b/cli/src/parsers/mt103-parser.ts
@@ -3,75 +3,126 @@ import { PaymentRecord, MT103Message } from '../types';
 
 /**
  * SWIFT MT103 message parser for bank integration.
- * Parses MT103 single customer credit transfer messages and converts
- * them to PaymentRecord format for batch processing.
  *
- * MT103 field mappings:
- *   :20:  - Transaction Reference
- *   :23B: - Bank Operation Code
- *   :32A: - Value Date / Currency / Amount
- *   :50K: - Ordering Customer (sender)
- *   :52A: - Ordering Institution (sender BIC)
- *   :57A: - Account With Institution (receiver BIC)
- *   :59:  - Beneficiary Customer (receiver)
- *   :70:  - Remittance Information
- *   :71A: - Details of Charges
+ * Parses MT103 "Single Customer Credit Transfer" messages and converts them to
+ * PaymentRecord format for batch processing.
+ *
+ * ## Field support
+ *
+ * | Tag   | Name                        | Mapped to                           |
+ * |-------|-----------------------------|-------------------------------------|
+ * | :20:  | Transaction Reference       | `memo` (fallback when :70: absent)  |
+ * | :23B: | Bank Operation Code         | (informational, not mapped)         |
+ * | :32A: | Value Date / Currency / Amt | `valueDate`, `currency`, `amount`   |
+ * | :50K: | Ordering Customer           | `orderingCustomer` (account + name) |
+ * | :50A: | Ordering Customer (BIC)     | `orderingCustomer` (BIC form)       |
+ * | :52A: | Ordering Institution        | `senderBIC`                         |
+ * | :57A: | Account With Institution    | `receiverBIC`                       |
+ * | :59:  | Beneficiary Customer        | `beneficiaryAccount` + `destination`|
+ * | :59A: | Beneficiary Customer (BIC)  | `beneficiaryCustomer`               |
+ * | :70:  | Remittance Information      | `remittanceInfo` → `memo`           |
+ * | :71A: | Details of Charges          | (informational, not mapped)         |
+ * | :72:  | Sender-to-Receiver Info     | (informational, not mapped)         |
+ *
+ * ## Field 32A — Value Date / Currency / Amount
+ *
+ * Format: `YYMMDD` + ISO-4217 currency code (3 uppercase letters) + amount.
+ * The amount uses a comma as the decimal separator per SWIFT convention;
+ * this parser normalises it to a period.  A trailing comma (e.g. `USD1000,`)
+ * is treated as a whole-number amount.
+ *
+ * ## Field 59 — Beneficiary Customer
+ *
+ * The field may start with an account number (IBAN, Stellar address, etc.) on
+ * the tag line or on the first continuation line, followed by the beneficiary
+ * name on subsequent lines.
+ *
+ * Parsing priority:
+ * 1. A 56-character Stellar public key (`G[A-Z2-7]{55}`) anywhere in the field
+ *    value — used directly as the payment destination.
+ * 2. An `/`-prefixed IBAN / account string on the first line of the field value
+ *    (e.g. `/DE89370400440532013000`).
+ * 3. The raw first non-empty line of the field value as a fallback.
+ *
+ * ## Field 70 — Remittance Information
+ *
+ * May span multiple continuation lines (each prefixed with `/`).  The parser
+ * joins them into a single string, stripping the leading `/` from each line,
+ * and trims whitespace.  When field :70: is absent the transaction reference
+ * from field :20: is used as the memo.
+ *
+ * ## Field 50K / 50A — Ordering Customer
+ *
+ * `:50K:` carries the account number on the first line (possibly on the same
+ * line as the tag) and the customer name on subsequent lines.
+ * `:50A:` carries only a BIC; both are stored in `orderingCustomer`.
+ * The ordering customer field is parsed correctly and does not bleed into
+ * the beneficiary destination — fields are isolated by the field-boundary
+ * regex.
+ *
+ * ## Multi-message files
+ *
+ * A file may contain multiple MT103 messages separated by `{4:` block
+ * delimiters.  Each message block is parsed independently.  Messages that lack
+ * both a beneficiary destination **and** an amount are silently skipped.
+ *
+ * ## Field boundary detection
+ *
+ * Multiline field values (`:50K:`, `:59:`, `:70:`) are captured up to the
+ * first of:
+ * - a newline followed by the next SWIFT tag (`\r?\n:[0-9A-Z]{2,3}:`), or
+ * - the block-end marker (`\r?\n-}`), or
+ * - end of string.
+ *
+ * This three-part lookahead prevents fields from consuming content in the next
+ * block when multiple messages are present in the same file.
  */
 export function parseMT103(filePath: string): PaymentRecord[] {
   const content = fs.readFileSync(filePath, 'utf-8');
   const messages = splitMT103Messages(content);
-  return messages.map(convertMT103ToPayment);
+  return messages
+    .map(convertMT103ToPayment)
+    .filter((r) => r !== null) as PaymentRecord[];
 }
 
-function splitMT103Messages(content: string): MT103Message[] {
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extended internal representation that carries all parsed MT103 fields before
+ * the final mapping to PaymentRecord.
+ */
+interface ParsedMT103 extends MT103Message {
+  /** Raw account identifier extracted from field :59: (before Stellar key detection). */
+  beneficiaryAccount: string;
+}
+
+/**
+ * Lookahead pattern that terminates a multiline field capture.
+ *
+ * Matches immediately before:
+ * - the start of any subsequent SWIFT tag (`\r?\n:[0-9A-Z]{2,3}:`), or
+ * - the MT103 block-end marker (`\r?\n-}`), or
+ * - the end of the string.
+ *
+ * Including `\r?\n-}` prevents multiline fields at the end of a block from
+ * consuming content in the next block when multiple messages are present.
+ */
+const FIELD_END = /(?=\r?\n:[0-9A-Z]{2,3}:|\r?\n-}|$)/;
+
+function splitMT103Messages(content: string): ParsedMT103[] {
+  // An MT103 file consists of one or more message blocks.  Each block begins
+  // with `{4:` (SWIFT block 4 delimiter) and ends at the next `{4:` or EOF.
   const messageBlocks = content.split(/\{4:/);
-  const messages: MT103Message[] = [];
+  const messages: ParsedMT103[] = [];
 
   for (const block of messageBlocks) {
     if (!block.trim()) continue;
 
-    const msg: MT103Message = {
-      senderBIC: '',
-      receiverBIC: '',
-      transactionRef: '',
-      valueDate: '',
-      currency: '',
-      amount: '',
-      orderingCustomer: '',
-      beneficiaryCustomer: '',
-      remittanceInfo: '',
-    };
+    const msg = parseMessageBlock(block);
 
-    const refMatch = block.match(/:20:(.+?)(?:\r?\n|$)/);
-    if (refMatch) msg.transactionRef = refMatch[1].trim();
-
-    const valueMatch = block.match(/:32A:(\d{6})([A-Z]{3})([0-9,.]+)/);
-    if (valueMatch) {
-      msg.valueDate = valueMatch[1];
-      msg.currency = valueMatch[2];
-      msg.amount = valueMatch[3].replace(',', '.');
-    }
-
-    const senderBICMatch = block.match(/:52A:(.+?)(?:\r?\n|$)/);
-    if (senderBICMatch) msg.senderBIC = senderBICMatch[1].trim();
-
-    const receiverBICMatch = block.match(/:57A:(.+?)(?:\r?\n|$)/);
-    if (receiverBICMatch) msg.receiverBIC = receiverBICMatch[1].trim();
-
-    const orderingMatch = block.match(/:50K:[\s\S]*?\n(.+?)(?:\r?\n:|$)/);
-    if (orderingMatch) msg.orderingCustomer = orderingMatch[1].trim();
-
-    const beneficiaryMatch = block.match(/:59:.*?\n?([A-Z0-9]{56}|G[A-Z0-9]{55})/);
-    if (beneficiaryMatch) {
-      msg.beneficiaryCustomer = beneficiaryMatch[1].trim();
-    } else {
-      const beneficiaryFallback = block.match(/:59:(.+?)(?:\r?\n:|$)/s);
-      if (beneficiaryFallback) msg.beneficiaryCustomer = beneficiaryFallback[1].trim().split('\n')[0];
-    }
-
-    const remittanceMatch = block.match(/:70:(.+?)(?:\r?\n:|$)/s);
-    if (remittanceMatch) msg.remittanceInfo = remittanceMatch[1].trim();
-
+    // Only keep messages with a usable destination and a non-zero amount.
     if (msg.beneficiaryCustomer && msg.amount) {
       messages.push(msg);
     }
@@ -80,26 +131,240 @@ function splitMT103Messages(content: string): MT103Message[] {
   return messages;
 }
 
-function convertMT103ToPayment(msg: MT103Message): PaymentRecord {
-  const assetMap: Record<string, string> = {
-    USD: 'USDC',
-    EUR: 'EURC',
-    GBP: 'GBP',
-    MXN: 'MXN',
-    BRL: 'BRL',
-    NGN: 'NGN',
-    KES: 'KES',
-    PHP: 'PHP',
-    INR: 'INR',
-    JPY: 'JPY',
+/**
+ * Build a regex that matches a specific SWIFT tag and captures its (possibly
+ * multiline) value, terminating at `FIELD_END`.
+ *
+ * @param tag  The tag text without colons, e.g. `'50K'`, `'59'`, `'70'`.
+ * @returns    A regex with capture group 1 being the raw field value.
+ */
+function fieldRegex(tag: string): RegExp {
+  return new RegExp(`:${tag}:([\\s\\S]*?)` + FIELD_END.source);
+}
+
+/**
+ * Parse a single MT103 block (the content after `{4:`) into a structured
+ * ParsedMT103 object.
+ */
+function parseMessageBlock(block: string): ParsedMT103 {
+  const msg: ParsedMT103 = {
+    senderBIC: '',
+    receiverBIC: '',
+    transactionRef: '',
+    valueDate: '',
+    currency: '',
+    amount: '',
+    orderingCustomer: '',
+    beneficiaryCustomer: '',
+    beneficiaryAccount: '',
+    remittanceInfo: '',
   };
 
+  // -------------------------------------------------------------------------
+  // :20: Transaction Reference
+  // -------------------------------------------------------------------------
+  const refMatch = block.match(/:20:([^\r\n]+)/);
+  if (refMatch) msg.transactionRef = refMatch[1].trim();
+
+  // -------------------------------------------------------------------------
+  // :32A: Value Date / Currency / Amount
+  //
+  // Format: YYMMDD + 3-letter ISO currency + amount (comma decimal separator,
+  // optional trailing comma for whole amounts, e.g. `250101USD1000,`).
+  // -------------------------------------------------------------------------
+  const valueMatch = block.match(/:32A:(\d{6})([A-Z]{3})([0-9,]+)/);
+  if (valueMatch) {
+    msg.valueDate = valueMatch[1];
+    msg.currency = valueMatch[2];
+    // Normalise: replace comma decimal separator with period, strip trailing comma.
+    const rawAmount = valueMatch[3].replace(/,$/, '').replace(',', '.');
+    msg.amount = rawAmount;
+  }
+
+  // -------------------------------------------------------------------------
+  // :52A: Ordering Institution (sender BIC)
+  // -------------------------------------------------------------------------
+  const senderBICMatch = block.match(/:52A:([^\r\n]+)/);
+  if (senderBICMatch) msg.senderBIC = senderBICMatch[1].trim();
+
+  // -------------------------------------------------------------------------
+  // :57A: Account With Institution (receiver BIC)
+  // -------------------------------------------------------------------------
+  const receiverBICMatch = block.match(/:57A:([^\r\n]+)/);
+  if (receiverBICMatch) msg.receiverBIC = receiverBICMatch[1].trim();
+
+  // -------------------------------------------------------------------------
+  // :50K: / :50A: Ordering Customer
+  //
+  // :50K: format:
+  //   :50K:<optional-account-on-same-line>
+  //   <name-line-1>
+  //   <name-line-2>  (optional)
+  //
+  // :50A: format:
+  //   :50A:<BIC>
+  //
+  // We capture the entire field value (everything until the next SWIFT tag,
+  // the block-end marker, or end of string) and normalise it.
+  // -------------------------------------------------------------------------
+  const ordering50KMatch = block.match(fieldRegex('50K'));
+  if (ordering50KMatch) {
+    msg.orderingCustomer = parseMultilineField(ordering50KMatch[1]);
+  } else {
+    const ordering50AMatch = block.match(/:50A:([^\r\n]+)/);
+    if (ordering50AMatch) msg.orderingCustomer = ordering50AMatch[1].trim();
+  }
+
+  // -------------------------------------------------------------------------
+  // :59: / :59A: Beneficiary Customer
+  //
+  // Field :59: may include an account on the tag line or the first continuation
+  // line, followed by the beneficiary name.  We attempt to find a Stellar
+  // public key first (56 chars, starts with G), then an IBAN-style `/`-prefixed
+  // account, then fall back to the raw first line.
+  //
+  // The tag pattern `:59:?` matches both `:59:` (plain) and `:59A:` / `:59B:`
+  // variants via the `?` on the optional letter suffix — but we handle :59A:
+  // separately below to avoid ambiguity.
+  //
+  // Field :59A: contains a BIC instead of an account number.
+  // -------------------------------------------------------------------------
+  const beneficiary59Match = block.match(/:59:([\s\S]*?)(?=\r?\n:[0-9A-Z]{2,3}:|\r?\n-}|$)/);
+  if (beneficiary59Match) {
+    parseBeneficiaryField(beneficiary59Match[1], msg);
+  } else {
+    // :59A: — BIC-based beneficiary (less common in direct Stellar use cases)
+    const beneficiary59AMatch = block.match(/:59A:([^\r\n]+)/);
+    if (beneficiary59AMatch) {
+      msg.beneficiaryCustomer = beneficiary59AMatch[1].trim();
+      msg.beneficiaryAccount = msg.beneficiaryCustomer;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // :70: Remittance Information
+  //
+  // May span multiple lines; each continuation line starts with `/`.
+  // We join them into a single string and strip the leading `/` separators.
+  // Falls back to :20: transaction reference when absent.
+  // -------------------------------------------------------------------------
+  const remittanceMatch = block.match(fieldRegex('70'));
+  if (remittanceMatch) {
+    msg.remittanceInfo = parseRemittanceField(remittanceMatch[1]);
+  }
+
+  return msg;
+}
+
+/**
+ * Parse field :59: content into msg.beneficiaryCustomer and
+ * msg.beneficiaryAccount.
+ *
+ * Priority:
+ * 1. Stellar public key (56 chars, G + base32) anywhere in the field value.
+ * 2. IBAN / account prefixed with `/` on the first non-empty line.
+ * 3. Raw first non-empty line as fallback.
+ */
+function parseBeneficiaryField(fieldValue: string, msg: ParsedMT103): void {
+  // Priority 1: Stellar public key (56 chars, starts with G, base32 alphabet)
+  const stellarKeyMatch = fieldValue.match(/\bG[A-Z2-7]{55}\b/);
+  if (stellarKeyMatch) {
+    msg.beneficiaryCustomer = stellarKeyMatch[0];
+    msg.beneficiaryAccount = stellarKeyMatch[0];
+    return;
+  }
+
+  // Priority 2: IBAN / account prefixed with /
+  const ibanMatch = fieldValue.match(/^\/([^\r\n]+)/m);
+  if (ibanMatch) {
+    msg.beneficiaryAccount = ibanMatch[1].trim();
+    // The account acts as the destination; name lines are informational only.
+    msg.beneficiaryCustomer = msg.beneficiaryAccount;
+    return;
+  }
+
+  // Priority 3: Raw first non-empty line
+  const firstLine = fieldValue.split(/\r?\n/).map((l) => l.trim()).find(Boolean) ?? '';
+  msg.beneficiaryCustomer = firstLine;
+  msg.beneficiaryAccount = firstLine;
+}
+
+/**
+ * Parse a multiline MT103 field value into a single trimmed string.
+ * Each line is stripped of leading/trailing whitespace; empty lines are dropped.
+ */
+function parseMultilineField(raw: string): string {
+  return raw
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .join(' ');
+}
+
+/**
+ * Parse a SWIFT :70: remittance field.
+ *
+ * SWIFT line continuation uses `/` as a line separator within structured
+ * narrative codes (e.g. `/INV/2024-001/RFB/PO-456`).  We strip the leading
+ * slash from each continuation line and join with a space so the result is
+ * human-readable while preserving all structured codes.
+ */
+function parseRemittanceField(raw: string): string {
+  const lines = raw.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  return lines
+    .map((l) => (l.startsWith('/') ? l.slice(1) : l))
+    .join(' ')
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Conversion: ParsedMT103 → PaymentRecord
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps ISO-4217 currency codes commonly found in MT103 messages to the
+ * corresponding Stellar/Soroban asset codes used in this SDK.
+ *
+ * Currencies not listed here pass through unchanged (e.g. `GBP` → `GBP`).
+ * This avoids silently coercing unknown currencies to `USDC`.
+ */
+const CURRENCY_TO_ASSET: Record<string, string> = {
+  USD: 'USDC',
+  EUR: 'EURC',
+  GBP: 'GBP',
+  MXN: 'MXN',
+  BRL: 'BRL',
+  NGN: 'NGN',
+  KES: 'KES',
+  PHP: 'PHP',
+  INR: 'INR',
+  JPY: 'JPY',
+  AED: 'AED',
+  CNY: 'CNY',
+  SGD: 'SGD',
+  HKD: 'HKD',
+};
+
+function convertMT103ToPayment(msg: ParsedMT103): PaymentRecord | null {
+  const destination = msg.beneficiaryAccount || msg.beneficiaryCustomer;
+
+  // Require a usable destination and a non-zero amount.
+  if (!destination || !msg.amount) return null;
+
+  // Prefer remittance info as memo; fall back to transaction reference.
+  // Memos are capped at 28 bytes for Stellar text memos — truncation happens
+  // in the transaction builder, not here, so we store the full value.
+  const memo = msg.remittanceInfo || msg.transactionRef || '';
+
   return {
-    destination: msg.beneficiaryCustomer,
+    destination,
     amount: msg.amount,
-    asset: assetMap[msg.currency] || msg.currency || 'USDC',
+    // Unknown currencies pass through unchanged rather than defaulting to USDC.
+    asset: CURRENCY_TO_ASSET[msg.currency] ?? msg.currency,
     asset_issuer: '',
-    memo: msg.remittanceInfo || msg.transactionRef || '',
-    escrow_duration: 86400, // Default 24h escrow for SWIFT transfers
+    memo,
+    // Default to 24-hour escrow for SWIFT bank transfers, matching the typical
+    // same-day SWIFT settlement window.
+    escrow_duration: 86400,
   };
 }

--- a/cli/src/utils/database.test.ts
+++ b/cli/src/utils/database.test.ts
@@ -1,0 +1,508 @@
+/**
+ * Tests for BatchDatabase — crash recovery and atomic state persistence.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { BatchDatabase } from './database';
+import {
+  BatchEntryStatus,
+  BatchPaymentEntry,
+  BatchStatus,
+  NetworkType,
+  TransactionGroup,
+} from '../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tmpDbPath(): string {
+  return path.join(
+    os.tmpdir(),
+    `stellar-payout-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+}
+
+function makeEntry(
+  index: number,
+  batchGroup: number,
+  overrides: Partial<BatchPaymentEntry> = {},
+): BatchPaymentEntry {
+  return {
+    index,
+    destination: `GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBN${String(index).padStart(5, '0')}`,
+    amount: '100.00',
+    asset: 'USDC',
+    asset_issuer: '',
+    memo: `payment-${index}`,
+    escrow_duration: 0,
+    status: BatchEntryStatus.Pending,
+    txHash: '',
+    error: '',
+    retryCount: 0,
+    submittedAt: 0,
+    completedAt: 0,
+    batchGroup,
+    ...overrides,
+  };
+}
+
+function makeGroup(groupIndex: number, overrides: Partial<TransactionGroup> = {}): TransactionGroup {
+  return {
+    groupIndex,
+    entries: [],
+    txHash: '',
+    status: BatchEntryStatus.Pending,
+    fee: '1000',
+    submittedAt: 0,
+    confirmedAt: 0,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('BatchDatabase', () => {
+  let dbPath: string;
+  let db: BatchDatabase;
+
+  beforeEach(() => {
+    dbPath = tmpDbPath();
+    db = new BatchDatabase(dbPath);
+  });
+
+  afterEach(() => {
+    db.close();
+    if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+  });
+
+  // -------------------------------------------------------------------------
+  // Batch creation and state
+  // -------------------------------------------------------------------------
+
+  describe('batch creation', () => {
+    it('createBatch sets status to running (delegates to initBatch)', () => {
+      db.createBatch('batch-1', 5, 'GABC', NetworkType.Testnet, false);
+      const state = db.getBatch('batch-1');
+      expect(state).not.toBeNull();
+      expect(state!.batchId).toBe('batch-1');
+      expect(state!.totalPayments).toBe(5);
+      expect(state!.sourceAccount).toBe('GABC');
+      expect(state!.network).toBe(NetworkType.Testnet);
+      expect(state!.dryRun).toBe(false);
+      // createBatch now delegates to initBatch which atomically sets 'running'
+      expect(state!.status).toBe(BatchStatus.Running);
+    });
+
+    it('initBatch atomically creates and sets status to running', () => {
+      db.initBatch('batch-init', 10, 'GXYZ', NetworkType.Mainnet, false);
+      const state = db.getBatch('batch-init')!;
+      expect(state.status).toBe(BatchStatus.Running);
+      expect(state.totalPayments).toBe(10);
+      expect(state.sourceAccount).toBe('GXYZ');
+      expect(state.network).toBe(NetworkType.Mainnet);
+    });
+
+    it('records dryRun flag correctly', () => {
+      db.createBatch('batch-dry', 3, 'GABC', NetworkType.Testnet, true);
+      expect(db.getBatch('batch-dry')!.dryRun).toBe(true);
+    });
+  });
+
+  describe('updateBatchStatus', () => {
+    it('transitions status from running to completed', () => {
+      db.createBatch('batch-2', 1, 'GABC', NetworkType.Testnet, false);
+      db.updateBatchStatus('batch-2', BatchStatus.Completed);
+      expect(db.getBatch('batch-2')!.status).toBe(BatchStatus.Completed);
+    });
+
+    it('sets completedAt when status is completed', () => {
+      db.createBatch('batch-3', 1, 'GABC', NetworkType.Testnet, false);
+      const before = Date.now();
+      db.updateBatchStatus('batch-3', BatchStatus.Completed);
+      const state = db.getBatch('batch-3')!;
+      expect(state.completedAt).not.toBeNull();
+      expect(state.completedAt!).toBeGreaterThanOrEqual(before);
+    });
+
+    it('does not set completedAt when transitioning to running', () => {
+      db.createBatch('batch-4', 1, 'GABC', NetworkType.Testnet, false);
+      // createBatch already sets running; pause first then re-check
+      db.markBatchPaused('batch-4');
+      db.updateBatchStatus('batch-4', BatchStatus.Running);
+      expect(db.getBatch('batch-4')!.completedAt).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // resumeBatch — atomic resume + counter refresh
+  // -------------------------------------------------------------------------
+
+  describe('resumeBatch', () => {
+    it('transitions status from paused to running', () => {
+      db.createBatch('batch-res', 2, 'GABC', NetworkType.Testnet, false);
+      db.markBatchPaused('batch-res');
+      expect(db.getBatch('batch-res')!.status).toBe(BatchStatus.Paused);
+      db.resumeBatch('batch-res');
+      expect(db.getBatch('batch-res')!.status).toBe(BatchStatus.Running);
+    });
+
+    it('refreshes counters on resume', () => {
+      db.createBatch('batch-rescnt', 3, 'GABC', NetworkType.Testnet, false);
+      db.insertEntries('batch-rescnt', [makeEntry(0, 0), makeEntry(1, 0), makeEntry(2, 0)]);
+      db.updateEntryStatus('batch-rescnt', 0, BatchEntryStatus.Confirmed, 'h0');
+      db.updateEntryStatus('batch-rescnt', 1, BatchEntryStatus.Failed);
+      db.markBatchPaused('batch-rescnt');
+      db.resumeBatch('batch-rescnt');
+
+      const state = db.getBatch('batch-rescnt')!;
+      expect(state.status).toBe(BatchStatus.Running);
+      expect(state.successfulPayments).toBe(1);
+      expect(state.failedPayments).toBe(1);
+    });
+
+    it('clears completedAt on resume', () => {
+      db.createBatch('batch-resclr', 1, 'GABC', NetworkType.Testnet, false);
+      db.updateBatchStatus('batch-resclr', BatchStatus.Completed);
+      db.resumeBatch('batch-resclr');
+      expect(db.getBatch('batch-resclr')!.completedAt).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getBatchesNeedingResume — stale batch detection
+  // -------------------------------------------------------------------------
+
+  describe('getBatchesNeedingResume', () => {
+    it('returns paused batches', () => {
+      db.createBatch('batch-stale1', 1, 'GABC', NetworkType.Testnet, false);
+      db.markBatchPaused('batch-stale1');
+      const stale = db.getBatchesNeedingResume();
+      expect(stale.map((b) => b.batchId)).toContain('batch-stale1');
+    });
+
+    it('returns running batches (crash without graceful shutdown)', () => {
+      db.createBatch('batch-stale2', 1, 'GABC', NetworkType.Testnet, false);
+      // createBatch → initBatch sets 'running' atomically, simulating a crash mid-run
+      const stale = db.getBatchesNeedingResume();
+      expect(stale.map((b) => b.batchId)).toContain('batch-stale2');
+    });
+
+    it('does not return completed or failed batches', () => {
+      db.createBatch('batch-done', 1, 'GABC', NetworkType.Testnet, false);
+      db.updateBatchStatus('batch-done', BatchStatus.Completed);
+      db.createBatch('batch-fail', 1, 'GABC', NetworkType.Testnet, false);
+      db.updateBatchStatus('batch-fail', BatchStatus.Failed);
+
+      const stale = db.getBatchesNeedingResume();
+      const ids = stale.map((b) => b.batchId);
+      expect(ids).not.toContain('batch-done');
+      expect(ids).not.toContain('batch-fail');
+    });
+
+    it('orders results by started_at descending', () => {
+      db.createBatch('batch-ord1', 1, 'GABC', NetworkType.Testnet, false);
+      db.markBatchPaused('batch-ord1');
+      db.createBatch('batch-ord2', 1, 'GABC', NetworkType.Testnet, false);
+      db.markBatchPaused('batch-ord2');
+
+      const stale = db.getBatchesNeedingResume();
+      const ids = stale.map((b) => b.batchId);
+      // Most recently started should appear first
+      expect(ids.indexOf('batch-ord2')).toBeLessThan(ids.indexOf('batch-ord1'));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // markBatchPaused — atomic pause + counter refresh
+  // -------------------------------------------------------------------------
+
+  describe('markBatchPaused', () => {
+    it('atomically sets status to paused and refreshes counters', () => {
+      db.createBatch('batch-pause', 3, 'GABC', NetworkType.Testnet, false);
+      const entries = [makeEntry(0, 0), makeEntry(1, 0), makeEntry(2, 0)];
+      db.insertEntries('batch-pause', entries);
+
+      db.updateEntryStatus('batch-pause', 0, BatchEntryStatus.Confirmed, 'hash-0');
+      db.updateEntryStatus('batch-pause', 1, BatchEntryStatus.Failed);
+      // entry 2 stays pending
+
+      db.markBatchPaused('batch-pause');
+      const state = db.getBatch('batch-pause')!;
+
+      expect(state.status).toBe(BatchStatus.Paused);
+      expect(state.successfulPayments).toBe(1);
+      expect(state.failedPayments).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Entry bulk insert — atomicity
+  // -------------------------------------------------------------------------
+
+  describe('insertEntries', () => {
+    it('inserts all entries in a single transaction', () => {
+      db.createBatch('batch-5', 3, 'GABC', NetworkType.Testnet, false);
+      const entries = [makeEntry(0, 0), makeEntry(1, 0), makeEntry(2, 1)];
+      db.insertEntries('batch-5', entries);
+
+      const stored = db.getEntries('batch-5');
+      expect(stored).toHaveLength(3);
+    });
+
+    it('preserves batchGroup on each entry', () => {
+      db.createBatch('batch-6', 2, 'GABC', NetworkType.Testnet, false);
+      db.insertEntries('batch-6', [makeEntry(0, 0), makeEntry(1, 1)]);
+
+      const stored = db.getEntries('batch-6');
+      expect(stored[0].batchGroup).toBe(0);
+      expect(stored[1].batchGroup).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // confirmGroupWithEntries — atomic group + entry confirmation
+  // -------------------------------------------------------------------------
+
+  describe('confirmGroupWithEntries', () => {
+    it('sets group status to confirmed with a tx hash', () => {
+      db.createBatch('batch-cg', 2, 'GABC', NetworkType.Testnet, false);
+      db.insertEntries('batch-cg', [makeEntry(0, 0), makeEntry(1, 0)]);
+      db.upsertGroup('batch-cg', makeGroup(0));
+
+      db.confirmGroupWithEntries('batch-cg', 0, 'abc123', [0, 1]);
+
+      const groups = db.getGroups('batch-cg');
+      expect(groups[0].txHash).toBe('abc123');
+      expect(groups[0].status).toBe(BatchEntryStatus.Confirmed);
+    });
+
+    it('sets all entry statuses to confirmed with the correct tx hash', () => {
+      db.createBatch('batch-ce', 2, 'GABC', NetworkType.Testnet, false);
+      db.insertEntries('batch-ce', [makeEntry(0, 0), makeEntry(1, 0)]);
+      db.upsertGroup('batch-ce', makeGroup(0));
+
+      db.confirmGroupWithEntries('batch-ce', 0, 'hash-xyz', [0, 1]);
+
+      const entries = db.getEntries('batch-ce');
+      for (const entry of entries) {
+        expect(entry.status).toBe(BatchEntryStatus.Confirmed);
+        expect(entry.txHash).toBe('hash-xyz');
+        expect(entry.completedAt).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // failGroupWithEntries — atomic group + entry failure
+  // -------------------------------------------------------------------------
+
+  describe('failGroupWithEntries', () => {
+    it('sets group status to failed', () => {
+      db.createBatch('batch-fg', 2, 'GABC', NetworkType.Testnet, false);
+      db.insertEntries('batch-fg', [makeEntry(0, 0), makeEntry(1, 0)]);
+      db.upsertGroup('batch-fg', makeGroup(0));
+
+      db.failGroupWithEntries('batch-fg', 0, 'horizon error', [0, 1]);
+
+      const groups = db.getGroups('batch-fg');
+      expect(groups[0].status).toBe(BatchEntryStatus.Failed);
+    });
+
+    it('increments retry_count on each failed entry', () => {
+      db.createBatch('batch-fr', 2, 'GABC', NetworkType.Testnet, false);
+      db.insertEntries('batch-fr', [makeEntry(0, 0), makeEntry(1, 0)]);
+      db.upsertGroup('batch-fr', makeGroup(0));
+
+      db.failGroupWithEntries('batch-fr', 0, 'error', [0, 1]);
+
+      const entries = db.getEntries('batch-fr');
+      for (const entry of entries) {
+        expect(entry.status).toBe(BatchEntryStatus.Failed);
+        expect(entry.retryCount).toBe(1);
+        expect(entry.error).toBe('error');
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // upsertGroup — idempotency
+  // -------------------------------------------------------------------------
+
+  describe('upsertGroup', () => {
+    it('creates a group row on first call', () => {
+      db.createBatch('batch-ug', 1, 'GABC', NetworkType.Testnet, false);
+      db.upsertGroup('batch-ug', makeGroup(0));
+
+      const groups = db.getGroups('batch-ug');
+      expect(groups).toHaveLength(1);
+      expect(groups[0].groupIndex).toBe(0);
+    });
+
+    it('updates an existing group row without creating a duplicate', () => {
+      db.createBatch('batch-ug2', 1, 'GABC', NetworkType.Testnet, false);
+      db.upsertGroup('batch-ug2', makeGroup(0, { status: BatchEntryStatus.Pending }));
+      db.upsertGroup('batch-ug2', makeGroup(0, { txHash: 'updated-hash', status: BatchEntryStatus.Confirmed }));
+
+      const groups = db.getGroups('batch-ug2');
+      expect(groups).toHaveLength(1);
+      expect(groups[0].txHash).toBe('updated-hash');
+      expect(groups[0].status).toBe(BatchEntryStatus.Confirmed);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // insertGroup — OR IGNORE idempotency
+  // -------------------------------------------------------------------------
+
+  describe('insertGroup', () => {
+    it('silently ignores a duplicate (batchId, groupIndex) insert', () => {
+      db.createBatch('batch-ig', 1, 'GABC', NetworkType.Testnet, false);
+      db.insertGroup('batch-ig', makeGroup(0, { txHash: 'first' }));
+      // Second insert for the same group should be ignored without throwing
+      expect(() => db.insertGroup('batch-ig', makeGroup(0, { txHash: 'second' }))).not.toThrow();
+
+      const groups = db.getGroups('batch-ig');
+      expect(groups).toHaveLength(1);
+      // The original insert is preserved
+      expect(groups[0].txHash).toBe('first');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getIncompleteGroups — resume support
+  // -------------------------------------------------------------------------
+
+  describe('getIncompleteGroups', () => {
+    it('returns only groups that are not confirmed', () => {
+      db.createBatch('batch-ic', 4, 'GABC', NetworkType.Testnet, false);
+      db.insertEntries('batch-ic', [
+        makeEntry(0, 0), makeEntry(1, 0),
+        makeEntry(2, 1), makeEntry(3, 1),
+      ]);
+
+      db.upsertGroup('batch-ic', makeGroup(0));
+      db.upsertGroup('batch-ic', makeGroup(1));
+
+      // Confirm group 0
+      db.confirmGroupWithEntries('batch-ic', 0, 'hash-0', [0, 1]);
+
+      const incomplete = db.getIncompleteGroups('batch-ic');
+      expect(incomplete).toHaveLength(1);
+      expect(incomplete[0].groupIndex).toBe(1);
+    });
+
+    it('returns empty array when all groups are confirmed', () => {
+      db.createBatch('batch-allc', 2, 'GABC', NetworkType.Testnet, false);
+      db.insertEntries('batch-allc', [makeEntry(0, 0), makeEntry(1, 0)]);
+      db.upsertGroup('batch-allc', makeGroup(0));
+      db.confirmGroupWithEntries('batch-allc', 0, 'hash-done', [0, 1]);
+
+      expect(db.getIncompleteGroups('batch-allc')).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getPendingEntriesByGroup — resume support
+  // -------------------------------------------------------------------------
+
+  describe('getPendingEntriesByGroup', () => {
+    it('returns only pending/submitted entries for the given group', () => {
+      db.createBatch('batch-pe', 3, 'GABC', NetworkType.Testnet, false);
+      db.insertEntries('batch-pe', [
+        makeEntry(0, 0),
+        makeEntry(1, 0),
+        makeEntry(2, 0),
+      ]);
+
+      // Confirm entry 0, leave 1 and 2 pending
+      db.updateEntryStatus('batch-pe', 0, BatchEntryStatus.Confirmed, 'hash-0');
+
+      const pending = db.getPendingEntriesByGroup('batch-pe', 0);
+      expect(pending.map((e) => e.index)).toEqual([1, 2]);
+    });
+
+    it('includes submitted entries (not yet confirmed)', () => {
+      db.createBatch('batch-sub', 2, 'GABC', NetworkType.Testnet, false);
+      db.insertEntries('batch-sub', [makeEntry(0, 0), makeEntry(1, 0)]);
+
+      db.updateEntryStatus('batch-sub', 0, BatchEntryStatus.Submitted, 'pending-hash');
+
+      const pending = db.getPendingEntriesByGroup('batch-sub', 0);
+      expect(pending).toHaveLength(2); // both submitted and pending
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // updateBatchCounters
+  // -------------------------------------------------------------------------
+
+  describe('updateBatchCounters', () => {
+    it('correctly counts confirmed, failed, and skipped entries', () => {
+      db.createBatch('batch-cnt', 4, 'GABC', NetworkType.Testnet, false);
+      const entries = [
+        makeEntry(0, 0), makeEntry(1, 0),
+        makeEntry(2, 1), makeEntry(3, 1),
+      ];
+      db.insertEntries('batch-cnt', entries);
+
+      db.updateEntryStatus('batch-cnt', 0, BatchEntryStatus.Confirmed, 'h0');
+      db.updateEntryStatus('batch-cnt', 1, BatchEntryStatus.Confirmed, 'h0');
+      db.updateEntryStatus('batch-cnt', 2, BatchEntryStatus.Failed);
+      db.updateEntryStatus('batch-cnt', 3, BatchEntryStatus.Skipped);
+
+      db.updateBatchCounters('batch-cnt');
+      const state = db.getBatch('batch-cnt')!;
+
+      expect(state.successfulPayments).toBe(2);
+      expect(state.failedPayments).toBe(1);
+      expect(state.skippedPayments).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getFailedEntries — retry support
+  // -------------------------------------------------------------------------
+
+  describe('getFailedEntries', () => {
+    it('returns only entries with failed status', () => {
+      db.createBatch('batch-fe', 3, 'GABC', NetworkType.Testnet, false);
+      db.insertEntries('batch-fe', [makeEntry(0, 0), makeEntry(1, 0), makeEntry(2, 0)]);
+
+      db.updateEntryStatus('batch-fe', 0, BatchEntryStatus.Confirmed, 'hash');
+      db.updateEntryStatus('batch-fe', 1, BatchEntryStatus.Failed);
+
+      const failed = db.getFailedEntries('batch-fe');
+      expect(failed).toHaveLength(1);
+      expect(failed[0].index).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getRecentBatches
+  // -------------------------------------------------------------------------
+
+  describe('getRecentBatches', () => {
+    it('returns batches ordered by started_at descending', () => {
+      db.createBatch('batch-r1', 1, 'GABC', NetworkType.Testnet, false);
+      db.createBatch('batch-r2', 2, 'GABC', NetworkType.Testnet, false);
+
+      const recent = db.getRecentBatches(10);
+      // Most recent should come first
+      expect(recent[0].batchId).toBe('batch-r2');
+      expect(recent[1].batchId).toBe('batch-r1');
+    });
+
+    it('respects the limit parameter', () => {
+      db.createBatch('batch-l1', 1, 'GABC', NetworkType.Testnet, false);
+      db.createBatch('batch-l2', 1, 'GABC', NetworkType.Testnet, false);
+      db.createBatch('batch-l3', 1, 'GABC', NetworkType.Testnet, false);
+
+      expect(db.getRecentBatches(2)).toHaveLength(2);
+    });
+  });
+});

--- a/cli/src/utils/database.ts
+++ b/cli/src/utils/database.ts
@@ -8,15 +8,101 @@ import {
   NetworkType,
 } from '../types';
 
+/**
+ * BatchDatabase — SQLite-backed persistence layer for batch payment state.
+ *
+ * ## Crash Recovery
+ *
+ * All writes that must be atomic are wrapped in explicit SQLite transactions
+ * so that a process crash mid-operation never leaves the database in a
+ * partially-written state.  The specific guarantees are:
+ *
+ * 1. **Batch initialisation** — `initBatch()` inserts the batch row *and*
+ *    immediately sets status to `running` in a single transaction.  There is
+ *    no window between creation and activation where a crash could leave a
+ *    batch stuck in `created`.  A crash before this completes leaves no trace;
+ *    processing must restart from the beginning.
+ *
+ * 2. **Entry seeding** — `insertEntries()` inserts all payment-entry rows in
+ *    one transaction.  Either every entry exists or none do.
+ *
+ * 3. **Group + entry confirmation** — `confirmGroupWithEntries()` updates the
+ *    transaction-group row *and* every associated payment-entry row atomically.
+ *    If the process is killed after Horizon returns a success hash but before
+ *    the writes complete, the whole update is rolled back so that `status` for
+ *    those entries remains `submitted` — not a false `confirmed`.  On the next
+ *    run the retry command will pick them up and re-check Horizon.
+ *
+ * 4. **Counter refresh** — `updateBatchCounters()` reads live entry stats and
+ *    writes them back in one transaction so the summary numbers are always
+ *    self-consistent.
+ *
+ * ## Resume After Crash / SIGINT
+ *
+ * When the process is interrupted (`SIGINT` / `SIGTERM`) the signal handler in
+ * `batch.ts` calls `db.markBatchPaused(batchId)` which atomically sets the
+ * batch status to `paused` and refreshes counters.  On restart:
+ *
+ * - `getBatchesNeedingResume()` returns all batches whose status is `paused`
+ *   or `running` (a `running` batch whose process no longer exists crashed
+ *   without calling `markBatchPaused`).  The batch command should call this on
+ *   startup and offer the operator an option to resume each one.
+ *
+ * - `resumeBatch(batchId)` atomically resets status to `running` and refreshes
+ *   counters.  Call this *before* re-entering the processing loop so that the
+ *   batch is never left in `paused` state while work is actively in progress.
+ *
+ * - `getIncompleteGroups(batchId)` returns every transaction group that has
+ *   not yet reached `confirmed` status, allowing the batch command to skip
+ *   already-confirmed groups and only reprocess incomplete ones.
+ *
+ * - `getPendingEntriesByGroup(batchId, groupIndex)` returns all entries for a
+ *   given group that are still `pending` or `submitted` (i.e. not yet
+ *   confirmed), so partial groups can be resumed correctly.
+ *
+ * - `upsertGroup()` is idempotent — re-inserting a group that already exists
+ *   (same batchId + groupIndex) updates it rather than creating a duplicate.
+ *
+ * - `stellar-payout retry --batch-id=<id>` retries every entry whose status
+ *   is `failed`.
+ *
+ * ### Full resume flow
+ *
+ * ```
+ * const paused = db.getBatchesNeedingResume();
+ * for (const batch of paused) {
+ *   db.resumeBatch(batch.batchId);                     // status → running
+ *   const incomplete = db.getIncompleteGroups(batch.batchId);
+ *   for (const group of incomplete) {
+ *     const pending = db.getPendingEntriesByGroup(batch.batchId, group.groupIndex);
+ *     // ... re-submit pending entries for this group
+ *   }
+ * }
+ * ```
+ *
+ * ## SQLite Settings
+ *
+ * - WAL journal mode: readers never block writers, writers never block readers.
+ * - `synchronous = FULL` (upgraded from NORMAL): the OS write-through cache is
+ *   flushed after each transaction commit, so a power loss cannot corrupt the
+ *   WAL file.  The slight throughput cost is acceptable given that the bottleneck
+ *   is always the Horizon HTTP round-trip, not SQLite writes.
+ */
 export class BatchDatabase {
   private db: Database.Database;
 
   constructor(dbPath: string) {
     this.db = new Database(dbPath);
     this.db.pragma('journal_mode = WAL');
-    this.db.pragma('synchronous = NORMAL');
+    // FULL ensures data reaches disk after every transaction commit.
+    // This is the safest setting for crash recovery.
+    this.db.pragma('synchronous = FULL');
     this.initialize();
   }
+
+  // ---------------------------------------------------------------------------
+  // Schema initialisation
+  // ---------------------------------------------------------------------------
 
   private initialize(): void {
     this.db.exec(`
@@ -64,56 +150,243 @@ export class BatchDatabase {
         fee TEXT NOT NULL DEFAULT '0',
         submitted_at INTEGER NOT NULL DEFAULT 0,
         confirmed_at INTEGER NOT NULL DEFAULT 0,
+        UNIQUE (batch_id, group_index),
         FOREIGN KEY (batch_id) REFERENCES batches(batch_id)
       );
 
       CREATE INDEX IF NOT EXISTS idx_entries_batch ON payment_entries(batch_id);
       CREATE INDEX IF NOT EXISTS idx_entries_status ON payment_entries(status);
+      CREATE INDEX IF NOT EXISTS idx_entries_batch_group ON payment_entries(batch_id, batch_group);
       CREATE INDEX IF NOT EXISTS idx_groups_batch ON transaction_groups(batch_id);
+      CREATE INDEX IF NOT EXISTS idx_groups_status ON transaction_groups(batch_id, status);
     `);
   }
 
-  createBatch(batchId: string, totalPayments: number, sourceAccount: string, network: NetworkType, dryRun: boolean): void {
-    this.db.prepare(`
-      INSERT INTO batches (batch_id, total_payments, started_at, status, source_account, network, dry_run)
-      VALUES (?, ?, ?, 'created', ?, ?, ?)
-    `).run(batchId, totalPayments, Date.now(), sourceAccount, network, dryRun ? 1 : 0);
+  // ---------------------------------------------------------------------------
+  // Batch lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Atomically create the batch record AND set its status to `running` in a
+   * single SQLite transaction.  This eliminates the crash window that existed
+   * when `createBatch` and `updateBatchStatus` were two separate calls —
+   * previously, a crash between those two calls would leave a batch stuck in
+   * `created` status, which `getBatchesNeedingResume()` would not detect.
+   *
+   * Callers that previously called `createBatch` + `updateBatchStatus(Running)`
+   * should migrate to this method.  `createBatch` is retained for backward
+   * compatibility but now delegates here.
+   */
+  initBatch(
+    batchId: string,
+    totalPayments: number,
+    sourceAccount: string,
+    network: NetworkType,
+    dryRun: boolean,
+  ): void {
+    const init = this.db.transaction(() => {
+      this.db
+        .prepare(
+          `INSERT INTO batches
+             (batch_id, total_payments, started_at, status, source_account, network, dry_run)
+           VALUES (?, ?, ?, 'running', ?, ?, ?)`,
+        )
+        .run(batchId, totalPayments, Date.now(), sourceAccount, network, dryRun ? 1 : 0);
+    });
+
+    init();
+  }
+
+  /**
+   * @deprecated Use `initBatch()` instead, which atomically creates the batch
+   * and sets its status to `running` in a single transaction.  This method is
+   * kept for backward compatibility and now delegates to `initBatch()`.
+   */
+  createBatch(
+    batchId: string,
+    totalPayments: number,
+    sourceAccount: string,
+    network: NetworkType,
+    dryRun: boolean,
+  ): void {
+    this.initBatch(batchId, totalPayments, sourceAccount, network, dryRun);
   }
 
   updateBatchStatus(batchId: string, status: BatchStatus): void {
-    const updates: Record<string, unknown> = { status };
-    if (status === BatchStatus.Completed || status === BatchStatus.Failed || status === BatchStatus.Cancelled) {
-      updates.completed_at = Date.now();
+    let completedAt: number | null = null;
+    if (
+      status === BatchStatus.Completed ||
+      status === BatchStatus.Failed ||
+      status === BatchStatus.Cancelled
+    ) {
+      completedAt = Date.now();
     }
-    this.db.prepare(`
-      UPDATE batches SET status = ?, completed_at = ? WHERE batch_id = ?
-    `).run(status, updates.completed_at || null, batchId);
+    this.db
+      .prepare(`UPDATE batches SET status = ?, completed_at = ? WHERE batch_id = ?`)
+      .run(status, completedAt, batchId);
   }
 
+  /**
+   * Atomically update batch counters by reading live stats from payment_entries.
+   * Called after every group completes and on graceful shutdown.
+   */
   updateBatchCounters(batchId: string): void {
-    const stats = this.db.prepare(`
-      SELECT
-        COUNT(*) as total,
-        SUM(CASE WHEN status IN ('submitted','confirmed') THEN 1 ELSE 0 END) as processed,
-        SUM(CASE WHEN status = 'confirmed' THEN 1 ELSE 0 END) as successful,
-        SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
-        SUM(CASE WHEN status = 'skipped' THEN 1 ELSE 0 END) as skipped
-      FROM payment_entries WHERE batch_id = ?
-    `).get(batchId) as Record<string, number>;
+    const refresh = this.db.transaction(() => {
+      const stats = this.db
+        .prepare(
+          `SELECT
+            COUNT(*)                                                          AS total,
+            SUM(CASE WHEN status IN ('submitted','confirmed') THEN 1 ELSE 0 END) AS processed,
+            SUM(CASE WHEN status = 'confirmed'  THEN 1 ELSE 0 END)           AS successful,
+            SUM(CASE WHEN status = 'failed'     THEN 1 ELSE 0 END)           AS failed,
+            SUM(CASE WHEN status = 'skipped'    THEN 1 ELSE 0 END)           AS skipped
+          FROM payment_entries WHERE batch_id = ?`,
+        )
+        .get(batchId) as Record<string, number>;
 
-    this.db.prepare(`
-      UPDATE batches SET
-        processed_payments = ?,
-        successful_payments = ?,
-        failed_payments = ?,
-        skipped_payments = ?
-      WHERE batch_id = ?
-    `).run(stats.processed, stats.successful, stats.failed, stats.skipped, batchId);
+      this.db
+        .prepare(
+          `UPDATE batches
+           SET processed_payments = ?,
+               successful_payments = ?,
+               failed_payments = ?,
+               skipped_payments = ?
+           WHERE batch_id = ?`,
+        )
+        .run(stats.processed, stats.successful, stats.failed, stats.skipped, batchId);
+    });
+
+    refresh();
+  }
+
+  /**
+   * Atomically sets batch status to `paused` and refreshes all counters.
+   * Called by signal handlers so that a single synchronous call is sufficient
+   * even in a signal context.
+   */
+  markBatchPaused(batchId: string): void {
+    const pauseAndCount = this.db.transaction(() => {
+      this.db
+        .prepare(`UPDATE batches SET status = ? WHERE batch_id = ?`)
+        .run(BatchStatus.Paused, batchId);
+
+      const stats = this.db
+        .prepare(
+          `SELECT
+            SUM(CASE WHEN status IN ('submitted','confirmed') THEN 1 ELSE 0 END) AS processed,
+            SUM(CASE WHEN status = 'confirmed'  THEN 1 ELSE 0 END)               AS successful,
+            SUM(CASE WHEN status = 'failed'     THEN 1 ELSE 0 END)               AS failed,
+            SUM(CASE WHEN status = 'skipped'    THEN 1 ELSE 0 END)               AS skipped
+          FROM payment_entries WHERE batch_id = ?`,
+        )
+        .get(batchId) as Record<string, number>;
+
+      this.db
+        .prepare(
+          `UPDATE batches
+           SET processed_payments = ?,
+               successful_payments = ?,
+               failed_payments = ?,
+               skipped_payments = ?
+           WHERE batch_id = ?`,
+        )
+        .run(stats.processed, stats.successful, stats.failed, stats.skipped, batchId);
+    });
+
+    pauseAndCount();
+  }
+
+  /**
+   * Atomically reset a paused (or stale-running) batch back to `running` and
+   * refresh all counters from live entry data.
+   *
+   * Call this at the start of a resume run — before re-entering the processing
+   * loop — so that the batch transitions cleanly from `paused` → `running`
+   * and the counters accurately reflect the work already done.
+   *
+   * After calling `resumeBatch`, use `getIncompleteGroups` and
+   * `getPendingEntriesByGroup` to determine which groups and entries still
+   * need processing.
+   */
+  resumeBatch(batchId: string): void {
+    const resume = this.db.transaction(() => {
+      this.db
+        .prepare(`UPDATE batches SET status = 'running', completed_at = NULL WHERE batch_id = ?`)
+        .run(batchId);
+
+      const stats = this.db
+        .prepare(
+          `SELECT
+            SUM(CASE WHEN status IN ('submitted','confirmed') THEN 1 ELSE 0 END) AS processed,
+            SUM(CASE WHEN status = 'confirmed'  THEN 1 ELSE 0 END)               AS successful,
+            SUM(CASE WHEN status = 'failed'     THEN 1 ELSE 0 END)               AS failed,
+            SUM(CASE WHEN status = 'skipped'    THEN 1 ELSE 0 END)               AS skipped
+          FROM payment_entries WHERE batch_id = ?`,
+        )
+        .get(batchId) as Record<string, number>;
+
+      this.db
+        .prepare(
+          `UPDATE batches
+           SET processed_payments = ?,
+               successful_payments = ?,
+               failed_payments = ?,
+               skipped_payments = ?
+           WHERE batch_id = ?`,
+        )
+        .run(stats.processed ?? 0, stats.successful ?? 0, stats.failed ?? 0, stats.skipped ?? 0, batchId);
+    });
+
+    resume();
+  }
+
+  /**
+   * Return all batches that require resume attention:
+   *
+   * - `paused` — process received SIGINT/SIGTERM and called `markBatchPaused`.
+   * - `running` — process crashed without a graceful shutdown; the status was
+   *   never updated from `running` to `paused`/`completed`/`failed`.
+   *
+   * Ordered most-recently-started first so the operator sees the newest stale
+   * batch at the top of the list.
+   *
+   * Typical usage:
+   * ```ts
+   * const stale = db.getBatchesNeedingResume();
+   * for (const batch of stale) {
+   *   db.resumeBatch(batch.batchId);
+   *   const groups = db.getIncompleteGroups(batch.batchId);
+   *   // ... re-process each incomplete group
+   * }
+   * ```
+   */
+  getBatchesNeedingResume(): BatchState[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM batches
+         WHERE status IN ('paused', 'running')
+         ORDER BY started_at DESC`,
+      )
+      .all() as Record<string, unknown>[];
+    return rows.map((r) => this.rowToBatchState(r));
   }
 
   getBatch(batchId: string): BatchState | null {
-    const row = this.db.prepare('SELECT * FROM batches WHERE batch_id = ?').get(batchId) as Record<string, unknown> | undefined;
+    const row = this.db
+      .prepare('SELECT * FROM batches WHERE batch_id = ?')
+      .get(batchId) as Record<string, unknown> | undefined;
     if (!row) return null;
+    return this.rowToBatchState(row);
+  }
+
+  getRecentBatches(limit: number = 10): BatchState[] {
+    const rows = this.db
+      .prepare('SELECT * FROM batches ORDER BY started_at DESC LIMIT ?')
+      .all(limit) as Record<string, unknown>[];
+    return rows.map((r) => this.rowToBatchState(r));
+  }
+
+  private rowToBatchState(row: Record<string, unknown>): BatchState {
     return {
       batchId: row.batch_id as string,
       totalPayments: row.total_payments as number,
@@ -130,95 +403,145 @@ export class BatchDatabase {
     };
   }
 
-  getRecentBatches(limit: number = 10): BatchState[] {
-    const rows = this.db.prepare('SELECT * FROM batches ORDER BY started_at DESC LIMIT ?').all(limit) as Record<string, unknown>[];
-    return rows.map((row) => ({
-      batchId: row.batch_id as string,
-      totalPayments: row.total_payments as number,
-      processedPayments: row.processed_payments as number,
-      successfulPayments: row.successful_payments as number,
-      failedPayments: row.failed_payments as number,
-      skippedPayments: row.skipped_payments as number,
-      startedAt: row.started_at as number,
-      completedAt: row.completed_at as number | null,
-      status: row.status as BatchStatus,
-      sourceAccount: row.source_account as string,
-      network: row.network as NetworkType,
-      dryRun: (row.dry_run as number) === 1,
-    }));
-  }
+  // ---------------------------------------------------------------------------
+  // Payment entries
+  // ---------------------------------------------------------------------------
 
   insertEntry(batchId: string, entry: BatchPaymentEntry): void {
-    this.db.prepare(`
-      INSERT INTO payment_entries (batch_id, entry_index, destination, amount, asset, asset_issuer, memo, escrow_duration, status, batch_group)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(batchId, entry.index, entry.destination, entry.amount, entry.asset, entry.asset_issuer, entry.memo, entry.escrow_duration, entry.status, entry.batchGroup);
+    this.db
+      .prepare(
+        `INSERT INTO payment_entries
+           (batch_id, entry_index, destination, amount, asset, asset_issuer,
+            memo, escrow_duration, status, batch_group)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        batchId,
+        entry.index,
+        entry.destination,
+        entry.amount,
+        entry.asset,
+        entry.asset_issuer,
+        entry.memo,
+        entry.escrow_duration,
+        entry.status,
+        entry.batchGroup,
+      );
   }
 
+  /**
+   * Bulk-insert all payment entries in a single atomic transaction.
+   * Either every row is written or none are — partial seeding is not possible.
+   */
   insertEntries(batchId: string, entries: BatchPaymentEntry[]): void {
-    const insert = this.db.prepare(`
-      INSERT INTO payment_entries (batch_id, entry_index, destination, amount, asset, asset_issuer, memo, escrow_duration, status, batch_group)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-    const transaction = this.db.transaction((items: BatchPaymentEntry[]) => {
+    const insert = this.db.prepare(
+      `INSERT INTO payment_entries
+         (batch_id, entry_index, destination, amount, asset, asset_issuer,
+          memo, escrow_duration, status, batch_group)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const bulkInsert = this.db.transaction((items: BatchPaymentEntry[]) => {
       for (const entry of items) {
-        insert.run(batchId, entry.index, entry.destination, entry.amount, entry.asset, entry.asset_issuer, entry.memo, entry.escrow_duration, entry.status, entry.batchGroup);
+        insert.run(
+          batchId,
+          entry.index,
+          entry.destination,
+          entry.amount,
+          entry.asset,
+          entry.asset_issuer,
+          entry.memo,
+          entry.escrow_duration,
+          entry.status,
+          entry.batchGroup,
+        );
       }
     });
-    transaction(entries);
+    bulkInsert(entries);
   }
 
-  updateEntryStatus(batchId: string, index: number, status: BatchEntryStatus, txHash?: string, errorMsg?: string): void {
+  updateEntryStatus(
+    batchId: string,
+    index: number,
+    status: BatchEntryStatus,
+    txHash?: string,
+    errorMsg?: string,
+  ): void {
     const now = Date.now();
     if (status === BatchEntryStatus.Submitted) {
-      this.db.prepare(`
-        UPDATE payment_entries SET status = ?, tx_hash = ?, submitted_at = ? WHERE batch_id = ? AND entry_index = ?
-      `).run(status, txHash || '', now, batchId, index);
+      this.db
+        .prepare(
+          `UPDATE payment_entries
+           SET status = ?, tx_hash = ?, submitted_at = ?
+           WHERE batch_id = ? AND entry_index = ?`,
+        )
+        .run(status, txHash ?? '', now, batchId, index);
     } else if (status === BatchEntryStatus.Confirmed) {
-      this.db.prepare(`
-        UPDATE payment_entries SET status = ?, tx_hash = ?, completed_at = ? WHERE batch_id = ? AND entry_index = ?
-      `).run(status, txHash || '', now, batchId, index);
+      this.db
+        .prepare(
+          `UPDATE payment_entries
+           SET status = ?, tx_hash = ?, completed_at = ?
+           WHERE batch_id = ? AND entry_index = ?`,
+        )
+        .run(status, txHash ?? '', now, batchId, index);
     } else if (status === BatchEntryStatus.Failed) {
-      this.db.prepare(`
-        UPDATE payment_entries SET status = ?, error = ?, retry_count = retry_count + 1 WHERE batch_id = ? AND entry_index = ?
-      `).run(status, errorMsg || '', batchId, index);
+      this.db
+        .prepare(
+          `UPDATE payment_entries
+           SET status = ?, error = ?, retry_count = retry_count + 1
+           WHERE batch_id = ? AND entry_index = ?`,
+        )
+        .run(status, errorMsg ?? '', batchId, index);
     } else {
-      this.db.prepare(`
-        UPDATE payment_entries SET status = ? WHERE batch_id = ? AND entry_index = ?
-      `).run(status, batchId, index);
+      this.db
+        .prepare(
+          `UPDATE payment_entries SET status = ? WHERE batch_id = ? AND entry_index = ?`,
+        )
+        .run(status, batchId, index);
     }
   }
 
   getEntries(batchId: string): BatchPaymentEntry[] {
-    const rows = this.db.prepare('SELECT * FROM payment_entries WHERE batch_id = ? ORDER BY entry_index').all(batchId) as Record<string, unknown>[];
-    return rows.map((row) => ({
-      index: row.entry_index as number,
-      destination: row.destination as string,
-      amount: row.amount as string,
-      asset: row.asset as string,
-      asset_issuer: (row.asset_issuer as string) || '',
-      memo: row.memo as string,
-      escrow_duration: row.escrow_duration as number,
-      status: row.status as BatchEntryStatus,
-      txHash: row.tx_hash as string,
-      error: row.error as string,
-      retryCount: row.retry_count as number,
-      submittedAt: row.submitted_at as number,
-      completedAt: row.completed_at as number,
-      batchGroup: row.batch_group as number,
-    }));
+    const rows = this.db
+      .prepare('SELECT * FROM payment_entries WHERE batch_id = ? ORDER BY entry_index')
+      .all(batchId) as Record<string, unknown>[];
+    return rows.map(this.rowToEntry);
   }
 
   getFailedEntries(batchId: string): BatchPaymentEntry[] {
-    const rows = this.db.prepare(
-      "SELECT * FROM payment_entries WHERE batch_id = ? AND status = 'failed' ORDER BY entry_index"
-    ).all(batchId) as Record<string, unknown>[];
-    return rows.map((row) => ({
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM payment_entries
+         WHERE batch_id = ? AND status = 'failed'
+         ORDER BY entry_index`,
+      )
+      .all(batchId) as Record<string, unknown>[];
+    return rows.map(this.rowToEntry);
+  }
+
+  /**
+   * Return all payment entries for a specific group whose status is still
+   * `pending` or `submitted`.  Used during resume to skip entries that were
+   * already confirmed in a previous run.
+   */
+  getPendingEntriesByGroup(batchId: string, groupIndex: number): BatchPaymentEntry[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM payment_entries
+         WHERE batch_id = ? AND batch_group = ?
+           AND status IN ('pending', 'submitted')
+         ORDER BY entry_index`,
+      )
+      .all(batchId, groupIndex) as Record<string, unknown>[];
+    return rows.map(this.rowToEntry);
+  }
+
+  private rowToEntry(row: Record<string, unknown>): BatchPaymentEntry {
+    return {
       index: row.entry_index as number,
       destination: row.destination as string,
       amount: row.amount as string,
       asset: row.asset as string,
-      asset_issuer: (row.asset_issuer as string) || '',
+      asset_issuer: (row.asset_issuer as string) ?? '',
       memo: row.memo as string,
       escrow_duration: row.escrow_duration as number,
       status: row.status as BatchEntryStatus,
@@ -228,26 +551,180 @@ export class BatchDatabase {
       submittedAt: row.submitted_at as number,
       completedAt: row.completed_at as number,
       batchGroup: row.batch_group as number,
-    }));
+    };
   }
 
+  // ---------------------------------------------------------------------------
+  // Transaction groups
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Insert a group record.  If a record for the same (batchId, groupIndex) pair
+   * already exists (e.g. process restarted after a crash mid-insert) the
+   * existing row is left unchanged — idempotent by design.
+   */
   insertGroup(batchId: string, group: TransactionGroup): void {
-    this.db.prepare(`
-      INSERT INTO transaction_groups (batch_id, group_index, tx_hash, status, fee, submitted_at, confirmed_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
-    `).run(batchId, group.groupIndex, group.txHash, group.status, group.fee, group.submittedAt, group.confirmedAt);
+    this.db
+      .prepare(
+        `INSERT OR IGNORE INTO transaction_groups
+           (batch_id, group_index, tx_hash, status, fee, submitted_at, confirmed_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        batchId,
+        group.groupIndex,
+        group.txHash,
+        group.status,
+        group.fee,
+        group.submittedAt,
+        group.confirmedAt,
+      );
   }
 
-  updateGroupStatus(batchId: string, groupIndex: number, status: BatchEntryStatus, txHash?: string): void {
+  /**
+   * Upsert a transaction group — creates it if absent, updates it if present.
+   * This is the preferred method when the caller cannot guarantee the group has
+   * not been inserted yet (e.g. after a crash mid-processing).
+   */
+  upsertGroup(batchId: string, group: TransactionGroup): void {
+    this.db
+      .prepare(
+        `INSERT INTO transaction_groups
+           (batch_id, group_index, tx_hash, status, fee, submitted_at, confirmed_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(batch_id, group_index) DO UPDATE SET
+           tx_hash      = excluded.tx_hash,
+           status       = excluded.status,
+           fee          = excluded.fee,
+           submitted_at = excluded.submitted_at,
+           confirmed_at = excluded.confirmed_at`,
+      )
+      .run(
+        batchId,
+        group.groupIndex,
+        group.txHash,
+        group.status,
+        group.fee,
+        group.submittedAt,
+        group.confirmedAt,
+      );
+  }
+
+  /**
+   * Atomically mark a transaction group as confirmed *and* update every
+   * associated payment entry to `confirmed` in one transaction.
+   *
+   * This prevents the inconsistency where a crash between updating the group
+   * row and updating the entry rows would leave entries perpetually stuck in
+   * `submitted` state even though the transaction succeeded on-chain.
+   */
+  confirmGroupWithEntries(
+    batchId: string,
+    groupIndex: number,
+    txHash: string,
+    entryIndices: number[],
+  ): void {
     const now = Date.now();
-    this.db.prepare(`
-      UPDATE transaction_groups SET status = ?, tx_hash = ?, confirmed_at = ? WHERE batch_id = ? AND group_index = ?
-    `).run(status, txHash || '', now, batchId, groupIndex);
+    const confirmGroup = this.db.transaction(() => {
+      // Update the group row
+      this.db
+        .prepare(
+          `UPDATE transaction_groups
+           SET status = 'confirmed', tx_hash = ?, confirmed_at = ?
+           WHERE batch_id = ? AND group_index = ?`,
+        )
+        .run(txHash, now, batchId, groupIndex);
+
+      // Update every entry in the group
+      const updateEntry = this.db.prepare(
+        `UPDATE payment_entries
+         SET status = 'confirmed', tx_hash = ?, completed_at = ?
+         WHERE batch_id = ? AND entry_index = ?`,
+      );
+      for (const idx of entryIndices) {
+        updateEntry.run(txHash, now, batchId, idx);
+      }
+    });
+
+    confirmGroup();
+  }
+
+  /**
+   * Atomically mark a transaction group as failed *and* update every associated
+   * payment entry to `failed` in one transaction.
+   */
+  failGroupWithEntries(
+    batchId: string,
+    groupIndex: number,
+    errorMsg: string,
+    entryIndices: number[],
+  ): void {
+    const failGroup = this.db.transaction(() => {
+      this.db
+        .prepare(
+          `UPDATE transaction_groups
+           SET status = 'failed'
+           WHERE batch_id = ? AND group_index = ?`,
+        )
+        .run(batchId, groupIndex);
+
+      const updateEntry = this.db.prepare(
+        `UPDATE payment_entries
+         SET status = 'failed',
+             error = ?,
+             retry_count = retry_count + 1
+         WHERE batch_id = ? AND entry_index = ?`,
+      );
+      for (const idx of entryIndices) {
+        updateEntry.run(errorMsg, batchId, idx);
+      }
+    });
+
+    failGroup();
+  }
+
+  updateGroupStatus(
+    batchId: string,
+    groupIndex: number,
+    status: BatchEntryStatus,
+    txHash?: string,
+  ): void {
+    const now = Date.now();
+    this.db
+      .prepare(
+        `UPDATE transaction_groups
+         SET status = ?, tx_hash = ?, confirmed_at = ?
+         WHERE batch_id = ? AND group_index = ?`,
+      )
+      .run(status, txHash ?? '', now, batchId, groupIndex);
+  }
+
+  /**
+   * Return all transaction groups for a batch that have not reached `confirmed`
+   * status.  Used during resume to determine which groups still need processing.
+   */
+  getIncompleteGroups(batchId: string): TransactionGroup[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM transaction_groups
+         WHERE batch_id = ? AND status != 'confirmed'
+         ORDER BY group_index`,
+      )
+      .all(batchId) as Record<string, unknown>[];
+    return rows.map(this.rowToGroup);
   }
 
   getGroups(batchId: string): TransactionGroup[] {
-    const rows = this.db.prepare('SELECT * FROM transaction_groups WHERE batch_id = ? ORDER BY group_index').all(batchId) as Record<string, unknown>[];
-    return rows.map((row) => ({
+    const rows = this.db
+      .prepare(
+        'SELECT * FROM transaction_groups WHERE batch_id = ? ORDER BY group_index',
+      )
+      .all(batchId) as Record<string, unknown>[];
+    return rows.map(this.rowToGroup);
+  }
+
+  private rowToGroup(row: Record<string, unknown>): TransactionGroup {
+    return {
       groupIndex: row.group_index as number,
       entries: [],
       txHash: row.tx_hash as string,
@@ -255,8 +732,12 @@ export class BatchDatabase {
       fee: row.fee as string,
       submittedAt: row.submitted_at as number,
       confirmedAt: row.confirmed_at as number,
-    }));
+    };
   }
+
+  // ---------------------------------------------------------------------------
+  // Housekeeping
+  // ---------------------------------------------------------------------------
 
   close(): void {
     this.db.close();

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "target": "ES2020",
     "module": "commonjs",
     "lib": ["ES2020"],

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,477 @@
+# Contract Deployment Guide
+
+This document covers everything needed to compile the Soroban smart contracts, deploy them to testnet or mainnet, and wire the resulting addresses into the SDK and CLI.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Build order overview](#build-order-overview)
+- [1. Compile the Rust contracts](#1-compile-the-rust-contracts)
+- [2. Deploy to testnet](#2-deploy-to-testnet)
+  - [2a. Generate and fund an admin keypair](#2a-generate-and-fund-an-admin-keypair)
+  - [2b. Deploy the three contracts](#2b-deploy-the-three-contracts)
+  - [2c. Initialise each contract](#2c-initialise-each-contract)
+  - [2d. Seed the rate oracle](#2d-seed-the-rate-oracle)
+  - [2e. Register compliance users](#2e-register-compliance-users)
+- [3. Verify deployed contracts](#3-verify-deployed-contracts)
+- [4. Wire addresses into the SDK](#4-wire-addresses-into-the-sdk)
+- [5. Wire addresses into the CLI](#5-wire-addresses-into-the-cli)
+- [6. Deploy to mainnet](#6-deploy-to-mainnet)
+- [Example testnet addresses](#example-testnet-addresses)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Prerequisites
+
+| Tool | Version | Install |
+|---|---|---|
+| Rust + Cargo | stable (≥1.78) | `curl https://sh.rustup.rs -sSf \| sh` |
+| wasm32 target | — | `rustup target add wasm32-unknown-unknown` |
+| Stellar CLI | ≥21 | see below |
+| Node.js | ≥18 | https://nodejs.org |
+
+**Install Stellar CLI:**
+
+```bash
+# via cargo (recommended)
+cargo install --locked stellar-cli@21
+
+# verify
+stellar --version
+```
+
+> On Windows use the PowerShell installer from
+> https://github.com/stellar/stellar-cli/releases or run inside WSL2.
+
+---
+
+## Build order overview
+
+```
+src/ (Rust contracts)
+  └── cargo build --release → target/wasm32-unknown-unknown/release/*.wasm
+        │
+        ▼  (deploy, get contract IDs)
+sdk/
+  └── npm run build → sdk/dist/      (depends on contract addresses in .env)
+        │
+        ▼
+cli/
+  └── npm run build → cli/dist/
+        │
+        ▼
+ui/
+  └── npm run build → ui/.next/
+```
+
+Use the top-level scripts to run the TypeScript part:
+
+```bash
+# Full build (contracts + all TS packages)
+npm run build:full
+
+# Or step by step
+npm run build:contracts
+npm run build:sdk
+npm run build:cli
+npm run build:ui
+
+# Type-check only (no emit)
+npm run type-check
+```
+
+---
+
+## 1. Compile the Rust contracts
+
+```bash
+# From the repo root
+cargo build --release --target wasm32-unknown-unknown
+```
+
+The compiled WASM artefact is a single library that exports all four contracts:
+
+```
+target/wasm32-unknown-unknown/release/stellar_cross_border_payments_sdk.wasm
+```
+
+Optimise for size (optional but recommended for mainnet):
+
+```bash
+# Requires wasm-opt from binaryen
+wasm-opt -Oz \
+  target/wasm32-unknown-unknown/release/stellar_cross_border_payments_sdk.wasm \
+  -o target/wasm32-unknown-unknown/release/stellar_cross_border_payments_sdk_opt.wasm
+```
+
+Run the contract unit tests before deploying:
+
+```bash
+cargo test
+```
+
+---
+
+## 2. Deploy to testnet
+
+### 2a. Generate and fund an admin keypair
+
+```bash
+# Generate a new keypair for the admin account
+stellar keys generate admin --network testnet
+
+# Print the public key
+stellar keys address admin
+
+# Fund via Friendbot (testnet only — gives 10,000 XLM)
+stellar keys fund admin --network testnet
+```
+
+Store the secret key in your `.env`:
+
+```bash
+# Copy the template first if you haven't already
+cp .env.example .env
+```
+
+Then set:
+
+```dotenv
+ADMIN_SECRET_KEY=<output of: stellar keys show admin>
+ADMIN_PUBLIC_KEY=<output of: stellar keys address admin>
+```
+
+> Never commit a `.env` file with real keys. The `.gitignore` already excludes it.
+
+---
+
+### 2b. Deploy the three contracts
+
+Each `stellar contract deploy` call uploads the WASM to the network and
+returns a **contract ID** — a 56-character string starting with `C`.
+
+```bash
+WASM=target/wasm32-unknown-unknown/release/stellar_cross_border_payments_sdk.wasm
+
+# Deploy Escrow contract
+ESCROW_CONTRACT_ADDRESS=$(stellar contract deploy \
+  --wasm "$WASM" \
+  --source admin \
+  --network testnet \
+  --alias escrow)
+echo "Escrow contract:     $ESCROW_CONTRACT_ADDRESS"
+
+# Deploy Rate Oracle contract
+RATE_ORACLE_CONTRACT_ADDRESS=$(stellar contract deploy \
+  --wasm "$WASM" \
+  --source admin \
+  --network testnet \
+  --alias rate_oracle)
+echo "Rate Oracle contract: $RATE_ORACLE_CONTRACT_ADDRESS"
+
+# Deploy Compliance contract
+COMPLIANCE_CONTRACT_ADDRESS=$(stellar contract deploy \
+  --wasm "$WASM" \
+  --source admin \
+  --network testnet \
+  --alias compliance)
+echo "Compliance contract:  $COMPLIANCE_CONTRACT_ADDRESS"
+```
+
+Update `.env` with the returned addresses:
+
+```dotenv
+ESCROW_CONTRACT_ADDRESS=C...
+RATE_ORACLE_CONTRACT_ADDRESS=C...
+COMPLIANCE_CONTRACT_ADDRESS=C...
+```
+
+---
+
+### 2c. Initialise each contract
+
+Every contract stores an admin address that must be set before any other
+functions can be called.  This is a one-time bootstrapping step.
+
+```bash
+ADMIN_PUBLIC=$(stellar keys address admin)
+
+# Initialise Compliance contract admin
+stellar contract invoke \
+  --id "$COMPLIANCE_CONTRACT_ADDRESS" \
+  --source admin \
+  --network testnet \
+  -- set_admin \
+  --admin "$ADMIN_PUBLIC"
+
+# Initialise Rate Oracle contract admin
+stellar contract invoke \
+  --id "$RATE_ORACLE_CONTRACT_ADDRESS" \
+  --source admin \
+  --network testnet \
+  -- set_admin \
+  --admin "$ADMIN_PUBLIC"
+
+# Initialise Anchor Registry admin
+stellar contract invoke \
+  --id "$ESCROW_CONTRACT_ADDRESS" \
+  --source admin \
+  --network testnet \
+  -- initialize \
+  --admin "$ADMIN_PUBLIC"
+```
+
+Add restricted jurisdictions (matches `.env` `RESTRICTED_JURISDICTIONS`):
+
+```bash
+for jurisdiction in IR NP KP; do
+  stellar contract invoke \
+    --id "$COMPLIANCE_CONTRACT_ADDRESS" \
+    --source admin \
+    --network testnet \
+    -- add_restricted_jurisdiction \
+    --jurisdiction "$jurisdiction"
+done
+```
+
+---
+
+### 2d. Seed the rate oracle
+
+The rate oracle aggregates rates from authorised sources.  For development,
+you can register the admin account as a rate source and submit initial rates.
+
+```bash
+# Register admin as a rate source (weight 100 = sole source in dev)
+stellar contract invoke \
+  --id "$RATE_ORACLE_CONTRACT_ADDRESS" \
+  --source admin \
+  --network testnet \
+  -- add_rate_source \
+  --name USD \
+  --address "$ADMIN_PUBLIC" \
+  --weight 100
+
+# Submit USD → MXN rate  (rate is scaled by 1,000,000 — 18.50 MXN = 18500000)
+stellar contract invoke \
+  --id "$RATE_ORACLE_CONTRACT_ADDRESS" \
+  --source admin \
+  --network testnet \
+  -- submit_rate \
+  --source "$ADMIN_PUBLIC" \
+  --from_currency USD \
+  --to_currency MXN \
+  --rate 18500000 \
+  --confidence 90
+
+# Submit USD → EUR rate  (0.92 EUR = 920000)
+stellar contract invoke \
+  --id "$RATE_ORACLE_CONTRACT_ADDRESS" \
+  --source admin \
+  --network testnet \
+  -- submit_rate \
+  --source "$ADMIN_PUBLIC" \
+  --from_currency USD \
+  --to_currency EUR \
+  --rate 920000 \
+  --confidence 90
+```
+
+---
+
+### 2e. Register compliance users
+
+Every account that sends or receives a payment must have a compliance record
+on-chain.  In production this is handled by your KYC provider; for local
+testing register the admin and any test accounts manually.
+
+```bash
+# Register admin / sender with basic KYC
+stellar contract invoke \
+  --id "$COMPLIANCE_CONTRACT_ADDRESS" \
+  --source admin \
+  --network testnet \
+  -- register_user \
+  --user "$ADMIN_PUBLIC" \
+  --kyc_level Basic \
+  --risk_level Low \
+  --jurisdiction US \
+  --aml_flags '[]' \
+  --transaction_limits '{"USDC":1000000000}'
+```
+
+---
+
+## 3. Verify deployed contracts
+
+```bash
+# Read back the rate you just submitted
+stellar contract invoke \
+  --id "$RATE_ORACLE_CONTRACT_ADDRESS" \
+  --source admin \
+  --network testnet \
+  -- get_rate \
+  --from_currency USD \
+  --to_currency MXN
+
+# Check compliance record
+stellar contract invoke \
+  --id "$COMPLIANCE_CONTRACT_ADDRESS" \
+  --source admin \
+  --network testnet \
+  -- get_user_compliance \
+  --user "$ADMIN_PUBLIC"
+```
+
+You can also inspect any contract on the Stellar testnet explorer:
+
+```
+https://stellar.expert/explorer/testnet/contract/<CONTRACT_ADDRESS>
+```
+
+---
+
+## 4. Wire addresses into the SDK
+
+```typescript
+// sdk usage — pass contract addresses to the SDK constructor
+import { StellarCrossBorderSDK } from '@stellar-cross-border/sdk';
+
+const config = StellarCrossBorderSDK.createTestnetConfig();
+
+const sdk = new StellarCrossBorderSDK(config, {
+  escrow:      process.env.ESCROW_CONTRACT_ADDRESS!,
+  rateOracle:  process.env.RATE_ORACLE_CONTRACT_ADDRESS!,
+  compliance:  process.env.COMPLIANCE_CONTRACT_ADDRESS!,
+});
+```
+
+The SDK reads the environment variables automatically when you use
+`dotenv.config()` at application startup, so a populated `.env` file is
+sufficient — no hard-coded addresses needed.
+
+---
+
+## 5. Wire addresses into the CLI
+
+Pass the addresses as flags or set them in `.env`:
+
+```bash
+# Via flags
+stellar-payout batch \
+  --input payments.csv \
+  --source-secret "$ADMIN_SECRET_KEY" \
+  --network testnet \
+  --escrow-contract "$ESCROW_CONTRACT_ADDRESS" \
+  --rate-oracle-contract "$RATE_ORACLE_CONTRACT_ADDRESS" \
+  --compliance-contract "$COMPLIANCE_CONTRACT_ADDRESS"
+
+# Or set in .env and omit the flags — the CLI reads them automatically
+stellar-payout batch --input payments.csv --source-secret "$ADMIN_SECRET_KEY"
+```
+
+---
+
+## 6. Deploy to mainnet
+
+The procedure mirrors testnet with three differences:
+
+1. Use `--network mainnet` in every `stellar` command.
+2. Fund the admin account with real XLM (minimum ~5 XLM per contract for
+   storage deposits plus transaction fees).
+3. Use `stellar_cross_border_payments_sdk_opt.wasm` (the wasm-opt output)
+   to reduce upload cost.
+
+```bash
+WASM=target/wasm32-unknown-unknown/release/stellar_cross_border_payments_sdk_opt.wasm
+
+ESCROW_CONTRACT_ADDRESS=$(stellar contract deploy \
+  --wasm "$WASM" \
+  --source admin \
+  --network mainnet \
+  --alias escrow_prod)
+
+RATE_ORACLE_CONTRACT_ADDRESS=$(stellar contract deploy \
+  --wasm "$WASM" \
+  --source admin \
+  --network mainnet \
+  --alias rate_oracle_prod)
+
+COMPLIANCE_CONTRACT_ADDRESS=$(stellar contract deploy \
+  --wasm "$WASM" \
+  --source admin \
+  --network mainnet \
+  --alias compliance_prod)
+```
+
+Then repeat the initialisation commands with `--network mainnet`.
+
+Update your production `.env` (or secrets manager) with the mainnet addresses
+and set:
+
+```dotenv
+HORIZON_URL=https://horizon.stellar.org
+SOROBAN_RPC_URL=https://soroban-rpc.mainnet.stellar.gateway.fm
+NETWORK_PASSPHRASE=Public Global Stellar Network ; September 2015
+```
+
+---
+
+## Example testnet addresses
+
+These addresses are provided for reference only and reflect a development
+deployment used during SDK testing.  They may be decommissioned at any time.
+Generate your own using the steps above.
+
+```dotenv
+# Testnet — development deployment (may be unavailable)
+HORIZON_URL=https://horizon-testnet.stellar.org
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+
+ESCROW_CONTRACT_ADDRESS=CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM
+RATE_ORACLE_CONTRACT_ADDRESS=CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFKU4
+COMPLIANCE_CONTRACT_ADDRESS=CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHB4
+```
+
+> These are placeholder addresses.  Replace them with your own deployed contract
+> IDs from the steps above.
+
+---
+
+## Troubleshooting
+
+**`wasm32-unknown-unknown` target missing**
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+**`stellar: command not found`**
+
+```bash
+cargo install --locked stellar-cli@21
+# Then add ~/.cargo/bin to PATH
+```
+
+**`Error: insufficient balance` during deploy**
+
+The admin account needs XLM to pay transaction fees and storage deposits.
+On testnet use Friendbot (`stellar keys fund admin --network testnet`).
+On mainnet purchase XLM and transfer to the admin address.
+
+**`Error: Admin not set` when invoking contract functions**
+
+You must call `set_admin` / `initialize` on each contract before any other
+function.  See [2c. Initialise each contract](#2c-initialise-each-contract).
+
+**Rate not found for currency pair**
+
+The rate oracle has no data for that pair.  Submit a rate with `submit_rate`
+as described in [2d. Seed the rate oracle](#2d-seed-the-rate-oracle).
+
+**`Error: User not registered` during compliance check**
+
+Register the sender and receiver accounts with `register_user` before
+submitting a payment.  See [2e. Register compliance users](#2e-register-compliance-users).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "stellar-cross-border-payments-sdk",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Monorepo root for the Stellar Cross-Border Payments SDK",
+  "workspaces": [
+    "sdk",
+    "cli",
+    "ui"
+  ],
+  "scripts": {
+    "install:all": "npm install --workspaces",
+
+    "build": "npm run build:sdk && npm run build:cli && npm run build:ui",
+    "build:sdk": "npm run build --workspace=sdk",
+    "build:cli": "npm run build --workspace=cli",
+    "build:ui": "npm run build --workspace=ui",
+    "build:contracts": "cargo build --release --target wasm32-unknown-unknown",
+
+    "build:full": "npm run build:contracts && npm run build",
+
+    "type-check": "npm run type-check:sdk && npm run type-check:cli && npm run type-check:ui",
+    "type-check:sdk": "tsc --noEmit --project sdk/tsconfig.json",
+    "type-check:cli": "tsc --noEmit --project cli/tsconfig.json",
+    "type-check:ui": "tsc --noEmit --project ui/tsconfig.json",
+
+    "test": "npm run test --workspace=sdk && npm run test --workspace=cli",
+    "test:sdk": "npm run test --workspace=sdk",
+    "test:cli": "npm run test --workspace=cli",
+    "test:contracts": "cargo test",
+
+    "lint": "npm run lint --workspace=sdk && npm run lint --workspace=cli && npm run lint --workspace=ui",
+    "lint:sdk": "npm run lint --workspace=sdk",
+    "lint:cli": "npm run lint --workspace=cli",
+    "lint:ui": "npm run lint --workspace=ui",
+
+    "clean": "npm run clean --workspace=sdk && npm run clean --workspace=cli",
+    "clean:contracts": "cargo clean",
+    "clean:all": "npm run clean && npm run clean:contracts",
+
+    "dev:sdk": "npm run dev --workspace=sdk",
+    "dev:cli": "npm run dev --workspace=cli",
+    "dev:ui": "npm run dev --workspace=ui"
+  },
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kryputh/stellar-cross-border-payments-sdk.git"
+  },
+  "license": "MIT"
+}

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,0 +1,146 @@
+<#
+.SYNOPSIS
+    Full monorepo build script for Windows PowerShell.
+
+.DESCRIPTION
+    Build order:
+      1. Rust Soroban contracts  → target\wasm32-unknown-unknown\release\*.wasm
+      2. SDK (TypeScript)        → sdk\dist\
+      3. CLI (TypeScript)        → cli\dist\
+      4. UI  (Next.js)           → ui\.next\
+
+    The SDK must be compiled before the CLI because the CLI workspace may
+    resolve the SDK from sdk\dist — the CLI build therefore requires sdk\dist
+    to exist first.
+
+.PARAMETER TsOnly
+    Skip the Rust contract build; only compile TypeScript packages.
+
+.PARAMETER ContractsOnly
+    Compile Rust contracts only; skip all TypeScript builds.
+
+.PARAMETER TypeCheck
+    Run tsc --noEmit on all TypeScript packages. Does not emit any files.
+
+.EXAMPLE
+    .\scripts\build.ps1
+    .\scripts\build.ps1 -TsOnly
+    .\scripts\build.ps1 -ContractsOnly
+    .\scripts\build.ps1 -TypeCheck
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$TsOnly,
+    [switch]$ContractsOnly,
+    [switch]$TypeCheck
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $RepoRoot
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+function Step  { param($msg) Write-Host "`n▶ $msg" -ForegroundColor Cyan }
+function Ok    { param($msg) Write-Host "✔ $msg"  -ForegroundColor Green }
+function Warn  { param($msg) Write-Host "⚠ $msg"  -ForegroundColor Yellow }
+function Die   { param($msg) Write-Error "✘ $msg"; exit 1 }
+
+function Require {
+    param($cmd, $hint)
+    if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
+        Die "$cmd not found. $hint"
+    }
+}
+
+# ── Tool checks ───────────────────────────────────────────────────────────────
+if (-not $TsOnly) {
+    Require 'cargo'  'Install Rust: https://rustup.rs'
+    Require 'rustup' 'Install Rust: https://rustup.rs'
+}
+
+if (-not $ContractsOnly) {
+    Require 'node' 'Install Node.js >=18: https://nodejs.org'
+    Require 'npm'  'Install Node.js >=18: https://nodejs.org'
+
+    $nodeMajor = [int](node -e "process.stdout.write(String(process.versions.node.split('.')[0]))")
+    if ($nodeMajor -lt 18) { Die "Node.js >=18 required (found $nodeMajor)" }
+}
+
+# ── 1. Rust Soroban contracts ─────────────────────────────────────────────────
+if (-not $TsOnly -and -not $TypeCheck) {
+    Step "Building Soroban contracts (wasm32-unknown-unknown)"
+
+    $installedTargets = rustup target list --installed
+    if ($installedTargets -notcontains 'wasm32-unknown-unknown') {
+        Step "Adding wasm32-unknown-unknown target"
+        rustup target add wasm32-unknown-unknown
+    }
+
+    cargo build --release --target wasm32-unknown-unknown
+    Ok "Contracts built → target\wasm32-unknown-unknown\release\*.wasm"
+
+    Get-ChildItem "target\wasm32-unknown-unknown\release\*.wasm" -ErrorAction SilentlyContinue |
+        ForEach-Object { "  $([math]::Round($_.Length / 1KB, 1)) KB  $($_.FullName)" | Write-Host }
+}
+
+if ($ContractsOnly) { Ok "Contract-only build complete."; exit 0 }
+
+# ── 2. Install npm workspaces ─────────────────────────────────────────────────
+if (-not $TypeCheck) {
+    Step "Installing npm workspace dependencies"
+    npm install --workspaces --include-workspace-root
+    Ok "Dependencies installed"
+}
+
+# ── 3. SDK ────────────────────────────────────────────────────────────────────
+Step "Building SDK (sdk/)"
+if ($TypeCheck) {
+    npx tsc --noEmit --project sdk/tsconfig.json
+    Ok "SDK type-check passed"
+} else {
+    npm run build --workspace=sdk
+    Ok "SDK built → sdk\dist\"
+}
+
+# ── 4. CLI ────────────────────────────────────────────────────────────────────
+Step "Building CLI (cli/)"
+if ($TypeCheck) {
+    npx tsc --noEmit --project cli/tsconfig.json
+    Ok "CLI type-check passed"
+} else {
+    npm run build --workspace=cli
+    Ok "CLI built → cli\dist\"
+}
+
+# ── 5. UI ─────────────────────────────────────────────────────────────────────
+Step "Building UI (ui/)"
+if ($TypeCheck) {
+    npm run type-check --workspace=ui
+    Ok "UI type-check passed"
+} else {
+    npm run build --workspace=ui
+    Ok "UI built → ui\.next\"
+}
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+Write-Host ""
+if ($TypeCheck) {
+    Ok "All type-checks passed."
+} else {
+    Ok "Full build complete."
+    Write-Host ""
+    Write-Host "  Artifacts:"
+    Write-Host "    Contracts  →  target\wasm32-unknown-unknown\release\"
+    Write-Host "    SDK        →  sdk\dist\"
+    Write-Host "    CLI        →  cli\dist\   (entry: cli\dist\index.js)"
+    Write-Host "    UI         →  ui\.next\"
+    Write-Host ""
+    Write-Host "  Run the CLI:"
+    Write-Host "    node cli\dist\index.js --help"
+    Write-Host ""
+    Write-Host "  Deploy contracts:"
+    Write-Host "    See docs\deployment.md"
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# =============================================================================
+# build.sh — Full monorepo build script
+#
+# Build order:
+#   1. Rust Soroban contracts  → target/wasm32-unknown-unknown/release/*.wasm
+#   2. SDK (TypeScript)        → sdk/dist/
+#   3. CLI (TypeScript)        → cli/dist/
+#   4. UI  (Next.js)           → ui/.next/
+#
+# The SDK must be compiled before the CLI because the CLI's node_modules may
+# symlink to the SDK workspace package — the CLI's build therefore requires
+# sdk/dist to exist first.
+#
+# Usage:
+#   ./scripts/build.sh                 # full build (contracts + all TS)
+#   ./scripts/build.sh --ts-only       # skip Rust, build TS packages only
+#   ./scripts/build.sh --contracts-only # compile Rust contracts only
+#   ./scripts/build.sh --type-check    # type-check all TS packages, no emit
+# =============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ── Colours ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+RESET='\033[0m'
+
+step()  { echo -e "\n${CYAN}▶ $*${RESET}"; }
+ok()    { echo -e "${GREEN}✔ $*${RESET}"; }
+warn()  { echo -e "${YELLOW}⚠ $*${RESET}"; }
+die()   { echo -e "${RED}✘ $*${RESET}" >&2; exit 1; }
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+TS_ONLY=false
+CONTRACTS_ONLY=false
+TYPE_CHECK=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --ts-only)         TS_ONLY=true ;;
+    --contracts-only)  CONTRACTS_ONLY=true ;;
+    --type-check)      TYPE_CHECK=true ;;
+    *) die "Unknown argument: $arg" ;;
+  esac
+done
+
+# ── Tool checks ───────────────────────────────────────────────────────────────
+if ! $TS_ONLY; then
+  command -v cargo >/dev/null 2>&1 || die "cargo not found. Install Rust: https://rustup.rs"
+  command -v rustup >/dev/null 2>&1 || die "rustup not found."
+fi
+
+if ! $CONTRACTS_ONLY; then
+  command -v node >/dev/null 2>&1 || die "node not found. Install Node.js >=18: https://nodejs.org"
+  command -v npm  >/dev/null 2>&1 || die "npm not found."
+
+  NODE_MAJOR=$(node -e "process.stdout.write(String(process.versions.node.split('.')[0]))")
+  (( NODE_MAJOR >= 18 )) || die "Node.js >=18 required (found $NODE_MAJOR)"
+fi
+
+# ── 1. Rust Soroban contracts ─────────────────────────────────────────────────
+if ! $TS_ONLY && ! $TYPE_CHECK; then
+  step "Building Soroban contracts (wasm32-unknown-unknown)"
+
+  # Ensure the wasm target is installed
+  if ! rustup target list --installed | grep -q "wasm32-unknown-unknown"; then
+    step "Adding wasm32-unknown-unknown target"
+    rustup target add wasm32-unknown-unknown
+  fi
+
+  cargo build --release --target wasm32-unknown-unknown
+  ok "Contracts built → target/wasm32-unknown-unknown/release/*.wasm"
+
+  # Print wasm sizes for quick sanity check
+  for wasm in target/wasm32-unknown-unknown/release/*.wasm; do
+    [[ -f "$wasm" ]] && echo "  $(du -sh "$wasm" | cut -f1)  $wasm"
+  done
+fi
+
+$CONTRACTS_ONLY && { ok "Contract-only build complete."; exit 0; }
+
+# ── 2. Install npm workspaces ─────────────────────────────────────────────────
+if ! $TYPE_CHECK; then
+  step "Installing npm workspace dependencies"
+  npm install --workspaces --include-workspace-root
+  ok "Dependencies installed"
+fi
+
+# ── 3. SDK ────────────────────────────────────────────────────────────────────
+step "Building SDK (sdk/)"
+if $TYPE_CHECK; then
+  npx tsc --noEmit --project sdk/tsconfig.json
+  ok "SDK type-check passed"
+else
+  npm run build --workspace=sdk
+  ok "SDK built → sdk/dist/"
+fi
+
+# ── 4. CLI ────────────────────────────────────────────────────────────────────
+step "Building CLI (cli/)"
+if $TYPE_CHECK; then
+  npx tsc --noEmit --project cli/tsconfig.json
+  ok "CLI type-check passed"
+else
+  npm run build --workspace=cli
+  ok "CLI built → cli/dist/"
+fi
+
+# ── 5. UI ─────────────────────────────────────────────────────────────────────
+step "Building UI (ui/)"
+if $TYPE_CHECK; then
+  npm run type-check --workspace=ui
+  ok "UI type-check passed"
+else
+  npm run build --workspace=ui
+  ok "UI built → ui/.next/"
+fi
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+echo ""
+if $TYPE_CHECK; then
+  ok "All type-checks passed."
+else
+  ok "Full build complete."
+  echo ""
+  echo "  Artifacts:"
+  echo "    Contracts  →  target/wasm32-unknown-unknown/release/"
+  echo "    SDK        →  sdk/dist/"
+  echo "    CLI        →  cli/dist/   (binary: cli/dist/index.js)"
+  echo "    UI         →  ui/.next/"
+  echo ""
+  echo "  Run the CLI:"
+  echo "    node cli/dist/index.js --help"
+  echo ""
+  echo "  Deploy contracts:"
+  echo "    See docs/deployment.md"
+fi

--- a/sdk/tsconfig.json
+++ b/sdk/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "target": "ES2020",
     "module": "commonjs",
     "lib": ["ES2020", "DOM"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  /**
+   * Root TypeScript project-references config.
+   *
+   * Running `tsc --build` from the repo root compiles sdk → cli in the correct
+   * dependency order (cli depends on sdk types).  The ui package uses Next.js
+   * which manages its own tsc invocation via `next build`, so it is not
+   * included as a reference here — use `npm run build:ui` for that.
+   *
+   * Individual package tsconfigs live in sdk/tsconfig.json and cli/tsconfig.json.
+   * They are standalone configs that can also be invoked directly.
+   */
+  "files": [],
+  "references": [
+    { "path": "./sdk" },
+    { "path": "./cli" }
+  ]
+}


### PR DESCRIPTION


- Add initBatch() for atomic create+running in one SQLite transaction, eliminating the crash window between createBatch and updateBatchStatus
- Add resumeBatch() to atomically reset paused/stale-running batches
- Add getBatchesNeedingResume() to detect graceful-pause and hard-crash batches
- Expand database.test.ts with initBatch, resumeBatch, and resume-detection suites
- Update batch.ts to call initBatch instead of createBatch+updateBatchStatus

- Rewrite mt103-parser.ts with FIELD_END lookahead including the block-end marker (-}) to prevent multiline fields consuming across message boundaries
- Extract parseBeneficiaryField() for clarity and testability
- Add full test coverage for :32A:, :59:, :70:, :50K: and multi-message files

- Add root package.json with npm workspaces (sdk, cli, ui) and full script set
- Add root tsconfig.json with project references (sdk -> cli build order)
- Add composite:true to sdk and cli tsconfigs to enable project references
- Add scripts/build.sh and scripts/build.ps1 with --ts-only, --contracts-only, and --type-check flags with artifact summary output
- Add docs/deployment.md covering contract compilation, testnet/mainnet deploy, contract initialisation, rate oracle seeding, compliance registration, SDK/CLI wiring, and troubleshooting
- Rewrite ci.yml to use root workspace scripts instead of per-package cd
- Update README with Building section, monorepo install steps, and deployment quick-start pointing to docs/deployment.md

Closes #30
Closes #31
Closes #45
Closes #47