### PR TITLE
feat: escrow token transfers + UI error states with retry controls

### DIFF
--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -1,0 +1,492 @@
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  KeyboardEvent,
+} from 'react';
+import { UseNotificationsReturn } from '../hooks/useNotifications';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface CommandAction {
+  id: string;
+  label: string;
+  description?: string;
+  /** Keyboard shortcut hint, e.g. "⌘K" */
+  shortcut?: string;
+  /** Icon element */
+  icon?: React.ReactNode;
+  /** Tags for fuzzy search */
+  keywords?: string[];
+  /** If true, the action is currently disabled (shown dimmed) */
+  disabled?: boolean;
+  onSelect: () => void | Promise<void>;
+}
+
+export interface CommandGroup {
+  id: string;
+  label: string;
+  actions: CommandAction[];
+}
+
+/** Async state for any operation triggered from the palette */
+interface ActionState {
+  actionId: string | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export interface CommandPaletteProps {
+  /**
+   * Groups of actions to display.
+   * Rate-fetch and compliance-check actions should be passed here;
+   * the palette will handle their loading/error/retry states.
+   */
+  groups: CommandGroup[];
+  /** Notification state — errors are forwarded as persistent notifications */
+  notificationState: UseNotificationsReturn;
+  /** Controlled open state */
+  open: boolean;
+  onClose: () => void;
+  /** Placeholder for the search input */
+  placeholder?: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function matches(action: CommandAction, query: string): boolean {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  if (action.label.toLowerCase().includes(q)) return true;
+  if (action.description?.toLowerCase().includes(q)) return true;
+  return action.keywords?.some(k => k.toLowerCase().includes(q)) ?? false;
+}
+
+// ─── Icons ────────────────────────────────────────────────────────────────────
+
+function IconSearch({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path fillRule="evenodd" d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z" clipRule="evenodd" />
+    </svg>
+  );
+}
+
+function IconSpinner({ className }: { className?: string }) {
+  return (
+    <svg className={`animate-spin ${className}`} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+    </svg>
+  );
+}
+
+function IconExclamation({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+    </svg>
+  );
+}
+
+function IconRefresh({ className, spinning }: { className?: string; spinning?: boolean }) {
+  return (
+    <svg
+      className={[className, spinning ? 'animate-spin' : ''].filter(Boolean).join(' ')}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path fillRule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clipRule="evenodd" />
+    </svg>
+  );
+}
+
+// ─── Action row ───────────────────────────────────────────────────────────────
+
+interface ActionRowProps {
+  action: CommandAction;
+  active: boolean;
+  state: ActionState;
+  onSelect: (action: CommandAction) => void;
+  onRetry: (action: CommandAction) => void;
+  onRef: (el: HTMLLIElement | null) => void;
+}
+
+function ActionRow({ action, active, state, onSelect, onRetry, onRef }: ActionRowProps) {
+  const isRunning = state.loading && state.actionId === action.id;
+  const hasFailed = !state.loading && state.error !== null && state.actionId === action.id;
+
+  return (
+    <li
+      ref={onRef}
+      role="option"
+      aria-selected={active}
+      id={`cmd-action-${action.id}`}
+      className={`flex cursor-default select-none items-center gap-3 rounded-md px-3 py-2.5 transition-colors ${
+        active ? 'bg-blue-600 text-white' : 'text-gray-900 hover:bg-gray-100'
+      } ${action.disabled ? 'pointer-events-none opacity-40' : ''}`}
+      onClick={() => !action.disabled && onSelect(action)}
+    >
+      {/* Optional custom icon */}
+      {action.icon && (
+        <span className={`shrink-0 ${active ? 'text-white' : 'text-gray-400'}`} aria-hidden="true">
+          {action.icon}
+        </span>
+      )}
+
+      {/* Labels */}
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-sm font-medium">{action.label}</span>
+        {action.description && (
+          <span className={`truncate text-xs ${active ? 'text-blue-200' : 'text-gray-400'}`}>
+            {action.description}
+          </span>
+        )}
+      </span>
+
+      {/* Right-side status */}
+      <span className="ml-auto flex items-center gap-1.5 shrink-0">
+        {/* Running spinner */}
+        {isRunning && (
+          <IconSpinner
+            className={`h-4 w-4 ${active ? 'text-white' : 'text-blue-600'}`}
+          />
+        )}
+
+        {/* Error badge + retry */}
+        {hasFailed && (
+          <>
+            <span
+              title={state.error ?? 'Failed'}
+              className={`flex items-center gap-0.5 rounded px-1.5 py-0.5 text-xs font-medium ${
+                active ? 'bg-white/20 text-white' : 'bg-red-100 text-red-700'
+              }`}
+            >
+              <IconExclamation className="h-3 w-3" />
+              Failed
+            </span>
+            <button
+              type="button"
+              onClick={e => { e.stopPropagation(); onRetry(action); }}
+              className={`rounded p-0.5 text-xs ${
+                active ? 'text-white hover:bg-white/20' : 'text-gray-500 hover:bg-gray-200'
+              } focus:outline-none focus-visible:ring-1 focus-visible:ring-blue-500`}
+              aria-label={`Retry ${action.label}`}
+            >
+              <IconRefresh className="h-3.5 w-3.5" />
+            </button>
+          </>
+        )}
+
+        {/* Shortcut hint */}
+        {action.shortcut && !isRunning && !hasFailed && (
+          <kbd
+            className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
+              active ? 'bg-blue-500 text-blue-100' : 'bg-gray-100 text-gray-400'
+            }`}
+          >
+            {action.shortcut}
+          </kbd>
+        )}
+      </span>
+    </li>
+  );
+}
+
+// ─── CommandPalette ───────────────────────────────────────────────────────────
+
+/**
+ * A keyboard-navigable command palette modal.
+ *
+ * Each action's `onSelect` is awaited; loading and error states are shown
+ * inline on the action row. On failure the error is also forwarded to the
+ * `notificationState` as a persistent notification with a retry callback.
+ *
+ * Usage:
+ * ```tsx
+ * const notifs = useNotifications();
+ * const [open, setOpen] = useState(false);
+ *
+ * const groups: CommandGroup[] = [
+ *   {
+ *     id: 'rates',
+ *     label: 'Exchange Rates',
+ *     actions: [
+ *       {
+ *         id: 'fetch-usd-mxn',
+ *         label: 'Refresh USD/MXN rate',
+ *         keywords: ['exchange', 'rate', 'usd', 'mxn'],
+ *         onSelect: async () => { await sdk.paymentsInstance.getExchangeRate(...) },
+ *       },
+ *     ],
+ *   },
+ * ];
+ *
+ * <CommandPalette
+ *   groups={groups}
+ *   notificationState={notifs}
+ *   open={open}
+ *   onClose={() => setOpen(false)}
+ * />
+ * ```
+ */
+export function CommandPalette({
+  groups,
+  notificationState,
+  open,
+  onClose,
+  placeholder = 'Search commands…',
+}: CommandPaletteProps) {
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [actionState, setActionState] = useState<ActionState>({
+    actionId: null,
+    loading: false,
+    error: null,
+  });
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const itemRefs = useRef<Map<string, HTMLLIElement>>(new Map());
+
+  // ── Filter ─────────────────────────────────────────────────────────────
+  const filtered: CommandGroup[] = groups
+    .map(group => ({
+      ...group,
+      actions: group.actions.filter(a => matches(a, query)),
+    }))
+    .filter(g => g.actions.length > 0);
+
+  const flatActions: CommandAction[] = filtered.flatMap(g => g.actions);
+
+  // Reset active index when results change
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  // Focus input on open
+  useEffect(() => {
+    if (open) {
+      setTimeout(() => inputRef.current?.focus(), 10);
+      setQuery('');
+      setActionState({ actionId: null, loading: false, error: null });
+    }
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const handle = (e: globalThis.KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handle);
+    return () => document.removeEventListener('keydown', handle);
+  }, [open, onClose]);
+
+  // ── Execute action ──────────────────────────────────────────────────────
+
+  const executeAction = useCallback(
+    async (action: CommandAction) => {
+      if (action.disabled) return;
+      if (actionState.loading) return;
+
+      setActionState({ actionId: action.id, loading: true, error: null });
+      try {
+        await action.onSelect();
+        setActionState({ actionId: action.id, loading: false, error: null });
+        onClose();
+      } catch (err: unknown) {
+        const message =
+          err instanceof Error ? err.message : 'An unexpected error occurred';
+        setActionState({ actionId: action.id, loading: false, error: message });
+
+        // Forward to the notification center as a persistent, retryable error
+        notificationState.notifyPaymentError(
+          `"${action.label}" failed: ${message}`,
+          err,
+          async () => {
+            // Retry from the notification center triggers the action again
+            await executeAction(action);
+          }
+        );
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [actionState.loading, notificationState, onClose]
+  );
+
+  const retryAction = useCallback(
+    (action: CommandAction) => {
+      setActionState({ actionId: action.id, loading: false, error: null });
+      executeAction(action);
+    },
+    [executeAction]
+  );
+
+  // ── Keyboard navigation ─────────────────────────────────────────────────
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      switch (e.key) {
+        case 'ArrowDown': {
+          e.preventDefault();
+          const next = Math.min(activeIndex + 1, flatActions.length - 1);
+          setActiveIndex(next);
+          const action = flatActions[next];
+          if (action) itemRefs.current.get(action.id)?.scrollIntoView({ block: 'nearest' });
+          break;
+        }
+        case 'ArrowUp': {
+          e.preventDefault();
+          const prev = Math.max(activeIndex - 1, 0);
+          setActiveIndex(prev);
+          const action = flatActions[prev];
+          if (action) itemRefs.current.get(action.id)?.scrollIntoView({ block: 'nearest' });
+          break;
+        }
+        case 'Enter': {
+          e.preventDefault();
+          const action = flatActions[activeIndex];
+          if (action) executeAction(action);
+          break;
+        }
+      }
+    },
+    [activeIndex, flatActions, executeAction]
+  );
+
+  if (!open) return null;
+
+  return (
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-gray-900/50 px-4 pt-[10vh]"
+      role="presentation"
+      onClick={e => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        role="dialog"
+        aria-label="Command palette"
+        aria-modal="true"
+        className="w-full max-w-xl overflow-hidden rounded-xl bg-white shadow-2xl ring-1 ring-black ring-opacity-5"
+      >
+        {/* Search input */}
+        <div className="flex items-center gap-2 border-b border-gray-100 px-4">
+          <IconSearch className="h-4 w-4 shrink-0 text-gray-400" />
+          <input
+            ref={inputRef}
+            role="combobox"
+            aria-expanded="true"
+            aria-autocomplete="list"
+            aria-controls="cmd-listbox"
+            aria-activedescendant={
+              flatActions[activeIndex]
+                ? `cmd-action-${flatActions[activeIndex].id}`
+                : undefined
+            }
+            type="text"
+            className="flex-1 border-0 bg-transparent py-4 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-0"
+            placeholder={placeholder}
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+          />
+          {actionState.loading && (
+            <IconSpinner className="h-4 w-4 shrink-0 text-blue-600" />
+          )}
+        </div>
+
+        {/* Inline error banner for the last failed action */}
+        {actionState.error && !actionState.loading && (
+          <div
+            role="alert"
+            className="flex items-start gap-2 border-b border-red-100 bg-red-50 px-4 py-2.5"
+          >
+            <IconExclamation className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+            <p className="min-w-0 flex-1 text-xs text-red-700">{actionState.error}</p>
+            <button
+              type="button"
+              onClick={() => {
+                const action = flatActions.find(a => a.id === actionState.actionId);
+                if (action) retryAction(action);
+              }}
+              className="ml-auto flex shrink-0 items-center gap-1 rounded px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-100 focus:outline-none focus-visible:ring-1 focus-visible:ring-red-500"
+            >
+              <IconRefresh className="h-3 w-3" />
+              Retry
+            </button>
+            <button
+              type="button"
+              onClick={() => setActionState(s => ({ ...s, error: null }))}
+              className="shrink-0 rounded p-1 text-red-400 hover:text-red-600 focus:outline-none focus-visible:ring-1 focus-visible:ring-red-500"
+              aria-label="Dismiss error"
+            >
+              <svg viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
+                <path d="M4 4l8 8m0-8l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+              </svg>
+            </button>
+          </div>
+        )}
+
+        {/* Results */}
+        <div className="max-h-80 overflow-y-auto" id="cmd-scroll-region">
+          {flatActions.length === 0 ? (
+            <p className="py-10 text-center text-sm text-gray-400">
+              {query ? `No results for "${query}"` : 'No commands available'}
+            </p>
+          ) : (
+            <ul
+              id="cmd-listbox"
+              role="listbox"
+              aria-label="Commands"
+              className="p-2"
+            >
+              {filtered.map(group => (
+                <li key={group.id} role="presentation">
+                  <p
+                    className="mb-1 mt-2 px-3 text-[10px] font-semibold uppercase tracking-wider text-gray-400"
+                    role="presentation"
+                  >
+                    {group.label}
+                  </p>
+                  <ul role="group" aria-label={group.label}>
+                    {group.actions.map(action => {
+                      const globalIdx = flatActions.indexOf(action);
+                      return (
+                        <ActionRow
+                          key={action.id}
+                          action={action}
+                          active={globalIdx === activeIndex}
+                          state={actionState}
+                          onSelect={executeAction}
+                          onRetry={retryAction}
+                          onRef={el => {
+                            if (el) itemRefs.current.set(action.id, el);
+                            else itemRefs.current.delete(action.id);
+                          }}
+                        />
+                      );
+                    })}
+                  </ul>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center gap-4 border-t border-gray-100 px-4 py-2">
+          <kbd className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] text-gray-500">↑↓</kbd>
+          <span className="text-[10px] text-gray-400">Navigate</span>
+          <kbd className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] text-gray-500">↵</kbd>
+          <span className="text-[10px] text-gray-400">Select</span>
+          <kbd className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] text-gray-500">Esc</kbd>
+          <span className="text-[10px] text-gray-400">Close</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CommandPalette;

--- a/components/NotificationCenter.tsx
+++ b/components/NotificationCenter.tsx
@@ -1,0 +1,451 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import {
+  Notification,
+  NotificationCategory,
+  NotificationType,
+  useNotifications,
+  UseNotificationsReturn,
+} from '../hooks/useNotifications';
+
+// ─── Icons (inline SVG, no external dependency) ──────────────────────────────
+
+function IconCheck({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+    </svg>
+  );
+}
+
+function IconXCircle({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+    </svg>
+  );
+}
+
+function IconExclamation({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+    </svg>
+  );
+}
+
+function IconInfo({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+    </svg>
+  );
+}
+
+function IconBell({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z" />
+    </svg>
+  );
+}
+
+function IconRefresh({ className, spinning }: { className?: string; spinning?: boolean }) {
+  return (
+    <svg
+      className={[className, spinning ? 'animate-spin' : ''].filter(Boolean).join(' ')}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path fillRule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clipRule="evenodd" />
+    </svg>
+  );
+}
+
+function IconX({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+    </svg>
+  );
+}
+
+// ─── Category label map ───────────────────────────────────────────────────────
+
+const CATEGORY_LABELS: Record<NotificationCategory, string> = {
+  exchange_rate: 'Exchange Rate',
+  compliance: 'Compliance',
+  payment: 'Payment',
+  escrow: 'Escrow',
+  network: 'Network',
+  general: 'General',
+};
+
+// ─── Per-type style tokens ────────────────────────────────────────────────────
+
+interface TypeStyle {
+  container: string;
+  icon: string;
+  iconColor: string;
+  badge: string;
+  Icon: React.FC<{ className?: string }>;
+}
+
+const TYPE_STYLES: Record<NotificationType, TypeStyle> = {
+  success: {
+    container: 'border-green-200 bg-green-50',
+    icon: 'bg-green-100',
+    iconColor: 'text-green-600',
+    badge: 'bg-green-100 text-green-800',
+    Icon: IconCheck,
+  },
+  error: {
+    container: 'border-red-200 bg-red-50',
+    icon: 'bg-red-100',
+    iconColor: 'text-red-600',
+    badge: 'bg-red-100 text-red-800',
+    Icon: IconXCircle,
+  },
+  warning: {
+    container: 'border-yellow-200 bg-yellow-50',
+    icon: 'bg-yellow-100',
+    iconColor: 'text-yellow-600',
+    badge: 'bg-yellow-100 text-yellow-800',
+    Icon: IconExclamation,
+  },
+  info: {
+    container: 'border-blue-200 bg-blue-50',
+    icon: 'bg-blue-100',
+    iconColor: 'text-blue-600',
+    badge: 'bg-blue-100 text-blue-800',
+    Icon: IconInfo,
+  },
+};
+
+// ─── Single notification row ──────────────────────────────────────────────────
+
+interface NotificationItemProps {
+  notification: Notification;
+  isRetrying: boolean;
+  onDismiss: (id: string) => void;
+  onRetry: (id: string) => Promise<void>;
+  onRead: (id: string) => void;
+}
+
+function NotificationItem({
+  notification,
+  isRetrying,
+  onDismiss,
+  onRetry,
+  onRead,
+}: NotificationItemProps) {
+  const styles = TYPE_STYLES[notification.type];
+  const { Icon } = styles;
+  const hasRetry = !!notification.onRetry;
+
+  const handleRetry = useCallback(async () => {
+    await onRetry(notification.id);
+  }, [notification.id, onRetry]);
+
+  const handleDismiss = useCallback(() => {
+    onDismiss(notification.id);
+  }, [notification.id, onDismiss]);
+
+  // Mark as read on mount if unread
+  useEffect(() => {
+    if (!notification.read) {
+      onRead(notification.id);
+    }
+    // Only run once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const age = formatAge(notification.createdAt);
+
+  return (
+    <li
+      role="listitem"
+      className={`flex gap-3 rounded-lg border p-4 ${styles.container} ${
+        !notification.read ? 'ring-2 ring-inset ring-current ring-opacity-10' : ''
+      }`}
+      aria-live={notification.type === 'error' ? 'assertive' : 'polite'}
+    >
+      {/* Icon */}
+      <span
+        className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full ${styles.icon}`}
+        aria-hidden="true"
+      >
+        <Icon className={`h-4 w-4 ${styles.iconColor}`} />
+      </span>
+
+      {/* Body */}
+      <div className="min-w-0 flex-1">
+        {/* Header row */}
+        <div className="mb-1 flex flex-wrap items-center gap-2">
+          <span className="text-sm font-semibold text-gray-900">{notification.title}</span>
+          <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${styles.badge}`}>
+            {CATEGORY_LABELS[notification.category]}
+          </span>
+          <span className="ml-auto text-xs text-gray-400">{age}</span>
+        </div>
+
+        {/* Message */}
+        <p className="text-sm text-gray-700">{notification.message}</p>
+
+        {/* Error detail (collapsed by default) */}
+        {notification.error && (
+          <ErrorDetail error={notification.error} />
+        )}
+
+        {/* Action row */}
+        {hasRetry && (
+          <div className="mt-3 flex gap-2">
+            <button
+              type="button"
+              onClick={handleRetry}
+              disabled={isRetrying}
+              className="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              aria-label={`Retry ${notification.title}`}
+            >
+              <IconRefresh className="h-3.5 w-3.5" spinning={isRetrying} />
+              {isRetrying ? 'Retrying…' : 'Retry'}
+            </button>
+            <button
+              type="button"
+              onClick={handleDismiss}
+              className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Dismiss (no retry) */}
+      {!hasRetry && (
+        <button
+          type="button"
+          onClick={handleDismiss}
+          className="ml-auto shrink-0 rounded p-1 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          aria-label="Dismiss notification"
+        >
+          <IconX className="h-4 w-4" />
+        </button>
+      )}
+    </li>
+  );
+}
+
+// ─── Collapsible error detail ─────────────────────────────────────────────────
+
+function ErrorDetail({ error }: { error: unknown }) {
+  const [expanded, setExpanded] = useState(false);
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+      ? error
+      : JSON.stringify(error);
+
+  return (
+    <div className="mt-1">
+      <button
+        type="button"
+        className="text-xs text-gray-500 underline hover:text-gray-700 focus:outline-none focus-visible:ring-1 focus-visible:ring-blue-500"
+        onClick={() => setExpanded(e => !e)}
+        aria-expanded={expanded}
+      >
+        {expanded ? 'Hide details' : 'Show details'}
+      </button>
+      {expanded && (
+        <pre className="mt-1 overflow-x-auto rounded bg-white/70 p-2 text-xs text-gray-600">
+          {message}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+// ─── Age formatter ────────────────────────────────────────────────────────────
+
+function formatAge(createdAt: number): string {
+  const seconds = Math.floor((Date.now() - createdAt) / 1000);
+  if (seconds < 60) return 'just now';
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  return `${Math.floor(seconds / 86400)}d ago`;
+}
+
+// ─── NotificationCenter props ─────────────────────────────────────────────────
+
+export interface NotificationCenterProps {
+  /**
+   * Pass the return value of `useNotifications()` so the component is
+   * controlled by whoever manages notification state.
+   */
+  notificationState: UseNotificationsReturn;
+  /** Where to anchor the dropdown panel. Defaults to 'right'. */
+  align?: 'left' | 'right';
+  /** Custom class for the trigger button wrapper */
+  className?: string;
+}
+
+// ─── NotificationCenter ───────────────────────────────────────────────────────
+
+/**
+ * A notification bell button that opens a dropdown panel listing all
+ * notifications. Error notifications with retry callbacks show a Retry button.
+ *
+ * Usage:
+ * ```tsx
+ * const notifs = useNotifications();
+ * <NotificationCenter notificationState={notifs} />
+ * ```
+ */
+export function NotificationCenter({
+  notificationState,
+  align = 'right',
+  className = '',
+}: NotificationCenterProps) {
+  const {
+    notifications,
+    unreadCount,
+    retry,
+    dismiss,
+    clearAll,
+    markAllAsRead,
+    markAsRead,
+    retryNotification,
+  } = notificationState;
+
+  const [open, setOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (
+        panelRef.current &&
+        !panelRef.current.contains(e.target as Node) &&
+        triggerRef.current &&
+        !triggerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    }
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open]);
+
+  const toggleOpen = useCallback(() => {
+    setOpen(v => {
+      if (!v) markAllAsRead();
+      return !v;
+    });
+  }, [markAllAsRead]);
+
+  const panelAlignClass = align === 'right' ? 'right-0' : 'left-0';
+
+  return (
+    <div className={`relative inline-block ${className}`}>
+      {/* Bell trigger */}
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={toggleOpen}
+        aria-label={`Notifications${unreadCount > 0 ? `, ${unreadCount} unread` : ''}`}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="relative rounded-full p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+      >
+        <IconBell className="h-5 w-5" />
+        {unreadCount > 0 && (
+          <span
+            aria-hidden="true"
+            className="absolute right-0.5 top-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold leading-none text-white"
+          >
+            {unreadCount > 9 ? '9+' : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {/* Panel */}
+      {open && (
+        <div
+          ref={panelRef}
+          role="dialog"
+          aria-label="Notifications"
+          className={`absolute ${panelAlignClass} z-50 mt-2 w-96 max-w-[calc(100vw-1rem)] origin-top-right rounded-xl bg-white shadow-xl ring-1 ring-black ring-opacity-5 focus:outline-none`}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+            <h2 className="text-sm font-semibold text-gray-900">
+              Notifications
+              {notifications.length > 0 && (
+                <span className="ml-1.5 text-xs font-normal text-gray-400">
+                  ({notifications.length})
+                </span>
+              )}
+            </h2>
+            <div className="flex items-center gap-2">
+              {notifications.length > 0 && (
+                <button
+                  type="button"
+                  onClick={clearAll}
+                  className="text-xs text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:underline"
+                >
+                  Clear all
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="rounded p-1 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                aria-label="Close notifications"
+              >
+                <IconX className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+
+          {/* List */}
+          <div className="max-h-[28rem] overflow-y-auto">
+            {notifications.length === 0 ? (
+              <p className="py-10 text-center text-sm text-gray-400">No notifications</p>
+            ) : (
+              <ul className="flex flex-col gap-2 p-3" role="list">
+                {notifications.map(n => (
+                  <NotificationItem
+                    key={n.id}
+                    notification={n}
+                    isRetrying={retry.retryingId === n.id}
+                    onDismiss={dismiss}
+                    onRetry={retryNotification}
+                    onRead={markAsRead}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default NotificationCenter;

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -1,0 +1,261 @@
+import { useState, useCallback, useRef } from 'react';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type NotificationType = 'info' | 'success' | 'warning' | 'error';
+
+export type NotificationCategory =
+  | 'exchange_rate'
+  | 'compliance'
+  | 'payment'
+  | 'escrow'
+  | 'network'
+  | 'general';
+
+export interface Notification {
+  id: string;
+  type: NotificationType;
+  category: NotificationCategory;
+  title: string;
+  message: string;
+  /** Original error, if any, for programmatic inspection */
+  error?: Error | unknown;
+  /** When the notification was created (ms since epoch) */
+  createdAt: number;
+  /** Whether the user has read/dismissed this notification */
+  read: boolean;
+  /** If provided, a retry callback will be shown alongside the notification */
+  onRetry?: () => void | Promise<void>;
+  /** Auto-dismiss after this many milliseconds (undefined = persistent) */
+  autoDismissMs?: number;
+}
+
+export interface RetryState {
+  /** Which notification ID is currently retrying */
+  retryingId: string | null;
+  /** Number of consecutive retry attempts for the active notification */
+  attempts: number;
+}
+
+export interface UseNotificationsReturn {
+  notifications: Notification[];
+  unreadCount: number;
+  retry: RetryState;
+
+  /** Add an arbitrary notification */
+  addNotification: (notification: Omit<Notification, 'id' | 'createdAt' | 'read'>) => string;
+
+  /** Convenience: report an exchange-rate fetch failure with a retry callback */
+  notifyRateError: (
+    message: string,
+    error: unknown,
+    retryFn: () => Promise<void>
+  ) => string;
+
+  /** Convenience: report a compliance check failure with a retry callback */
+  notifyComplianceError: (
+    message: string,
+    error: unknown,
+    retryFn: () => Promise<void>
+  ) => string;
+
+  /** Convenience: report a payment or escrow failure */
+  notifyPaymentError: (
+    message: string,
+    error: unknown,
+    retryFn?: () => Promise<void>
+  ) => string;
+
+  /** Convenience: report a success */
+  notifySuccess: (title: string, message: string, category?: NotificationCategory) => string;
+
+  /** Mark one notification as read */
+  markAsRead: (id: string) => void;
+
+  /** Mark all notifications as read */
+  markAllAsRead: () => void;
+
+  /** Remove a single notification */
+  dismiss: (id: string) => void;
+
+  /** Remove all notifications */
+  clearAll: () => void;
+
+  /**
+   * Trigger the retry callback for a notification.
+   * Tracks attempt count and marks the notification as retrying.
+   */
+  retryNotification: (id: string) => Promise<void>;
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+let _idCounter = 0;
+function nextId(): string {
+  return `notif-${Date.now()}-${++_idCounter}`;
+}
+
+export function useNotifications(): UseNotificationsReturn {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [retry, setRetry] = useState<RetryState>({ retryingId: null, attempts: 0 });
+
+  // Keep a ref so callbacks always see the latest list without stale closures
+  const notifsRef = useRef<Notification[]>([]);
+  notifsRef.current = notifications;
+
+  // ── Auto-dismiss timers ──────────────────────────────────────────────────
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const scheduleAutoDismiss = useCallback((id: string, ms: number) => {
+    if (timers.current.has(id)) clearTimeout(timers.current.get(id)!);
+    const handle = setTimeout(() => {
+      setNotifications(prev => prev.filter(n => n.id !== id));
+      timers.current.delete(id);
+    }, ms);
+    timers.current.set(id, handle);
+  }, []);
+
+  // ── Core add ─────────────────────────────────────────────────────────────
+
+  const addNotification = useCallback(
+    (notif: Omit<Notification, 'id' | 'createdAt' | 'read'>): string => {
+      const id = nextId();
+      const full: Notification = { ...notif, id, createdAt: Date.now(), read: false };
+      setNotifications(prev => [full, ...prev]);
+      if (full.autoDismissMs) scheduleAutoDismiss(id, full.autoDismissMs);
+      return id;
+    },
+    [scheduleAutoDismiss]
+  );
+
+  // ── Domain-specific helpers ───────────────────────────────────────────────
+
+  const notifyRateError = useCallback(
+    (message: string, error: unknown, retryFn: () => Promise<void>): string => {
+      return addNotification({
+        type: 'error',
+        category: 'exchange_rate',
+        title: 'Exchange Rate Unavailable',
+        message,
+        error,
+        onRetry: retryFn,
+      });
+    },
+    [addNotification]
+  );
+
+  const notifyComplianceError = useCallback(
+    (message: string, error: unknown, retryFn: () => Promise<void>): string => {
+      return addNotification({
+        type: 'error',
+        category: 'compliance',
+        title: 'Compliance Check Failed',
+        message,
+        error,
+        onRetry: retryFn,
+      });
+    },
+    [addNotification]
+  );
+
+  const notifyPaymentError = useCallback(
+    (message: string, error: unknown, retryFn?: () => Promise<void>): string => {
+      return addNotification({
+        type: 'error',
+        category: 'payment',
+        title: 'Payment Error',
+        message,
+        error,
+        onRetry: retryFn,
+      });
+    },
+    [addNotification]
+  );
+
+  const notifySuccess = useCallback(
+    (title: string, message: string, category: NotificationCategory = 'general'): string => {
+      return addNotification({
+        type: 'success',
+        category,
+        title,
+        message,
+        autoDismissMs: 5000,
+      });
+    },
+    [addNotification]
+  );
+
+  // ── State management ─────────────────────────────────────────────────────
+
+  const markAsRead = useCallback((id: string) => {
+    setNotifications(prev =>
+      prev.map(n => (n.id === id ? { ...n, read: true } : n))
+    );
+  }, []);
+
+  const markAllAsRead = useCallback(() => {
+    setNotifications(prev => prev.map(n => ({ ...n, read: true })));
+  }, []);
+
+  const dismiss = useCallback((id: string) => {
+    if (timers.current.has(id)) {
+      clearTimeout(timers.current.get(id)!);
+      timers.current.delete(id);
+    }
+    setNotifications(prev => prev.filter(n => n.id !== id));
+  }, []);
+
+  const clearAll = useCallback(() => {
+    timers.current.forEach(handle => clearTimeout(handle));
+    timers.current.clear();
+    setNotifications([]);
+  }, []);
+
+  // ── Retry ────────────────────────────────────────────────────────────────
+
+  const retryNotification = useCallback(
+    async (id: string): Promise<void> => {
+      const notif = notifsRef.current.find(n => n.id === id);
+      if (!notif?.onRetry) return;
+
+      setRetry(prev => ({
+        retryingId: id,
+        attempts: prev.retryingId === id ? prev.attempts + 1 : 1,
+      }));
+
+      // Mark as read while retrying so badge count drops
+      markAsRead(id);
+
+      try {
+        await notif.onRetry();
+        // On success, remove the error notification
+        dismiss(id);
+      } catch {
+        // Retry failed — keep the notification visible, reset retrying state
+      } finally {
+        setRetry(prev => (prev.retryingId === id ? { ...prev, retryingId: null } : prev));
+      }
+    },
+    [dismiss, markAsRead]
+  );
+
+  // ── Derived ──────────────────────────────────────────────────────────────
+
+  const unreadCount = notifications.filter(n => !n.read).length;
+
+  return {
+    notifications,
+    unreadCount,
+    retry,
+    addNotification,
+    notifyRateError,
+    notifyComplianceError,
+    notifyPaymentError,
+    notifySuccess,
+    markAsRead,
+    markAllAsRead,
+    dismiss,
+    clearAll,
+    retryNotification,
+  };
+}

--- a/src/escrow.rs
+++ b/src/escrow.rs
@@ -1,7 +1,12 @@
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol, Vec, Map, BytesN};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, Address, Bytes, BytesN, Env, Map, Symbol, Vec,
+};
+use soroban_sdk::token::Client as TokenClient;
+
+// ─── Data types ─────────────────────────────────────────────────────────────
 
 #[contracttype]
-
+#[derive(Clone, PartialEq)]
 pub enum EscrowStatus {
     Pending,
     Completed,
@@ -9,8 +14,9 @@ pub enum EscrowStatus {
     Disputed,
 }
 
+/// Metadata stored alongside a dispute submission.
 #[contracttype]
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct DisputeEvidence {
     pub dispute_id:   u64,
     pub submitter:    Address,
@@ -19,7 +25,42 @@ pub struct DisputeEvidence {
     pub description:  Symbol,
 }
 
-const EVIDENCE_KEY: &str = "dispute_evidence";
+/// Core escrow record.
+/// `#[contracttype]` is required for Soroban persistent-storage serialisation.
+#[contracttype]
+#[derive(Clone)]
+pub struct Escrow {
+    pub id:           BytesN<32>,
+    pub sender:       Address,
+    pub receiver:     Address,
+    pub amount:       i128,
+    pub token:        Address,
+    pub status:       EscrowStatus,
+    pub release_time: u64,
+    pub created_at:   u64,
+    pub metadata:     Map<Symbol, Vec<u8>>,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Dispute {
+    pub escrow_id:  BytesN<32>,
+    pub challenger: Address,
+    pub reason:     Symbol,
+    pub evidence:   Vec<u8>,
+    pub created_at: u64,
+    pub resolved:   bool,
+}
+
+// ─── Storage-key constants ───────────────────────────────────────────────────
+
+const ADMIN_KEY:     &str = "ADMIN";
+const INIT_KEY:      &str = "INITIALIZED";
+const ESCROW_KEY:    &str = "ESCROW";
+const DISPUTES_KEY:  &str = "DISPUTES";
+const EVIDENCE_KEY:  &str = "DISPUTE_EVIDENCE";
+
+// ─── Stand-alone evidence helpers (used in tests) ────────────────────────────
 
 pub fn store_evidence(env: &Env, dispute_id: u64, evidence: DisputeEvidence) {
     let key = (Symbol::new(env, EVIDENCE_KEY), dispute_id);
@@ -30,32 +71,17 @@ pub fn get_evidence(env: &Env, dispute_id: u64) -> Option<DisputeEvidence> {
     let key = (Symbol::new(env, EVIDENCE_KEY), dispute_id);
     env.storage().persistent().get(&key)
 }
-pub struct Escrow {
-    pub id: BytesN<32>,
-    pub sender: Address,
-    pub receiver: Address,
-    pub amount: i128,
-    pub token: Address,
-    pub status: EscrowStatus,
-    pub release_time: u64,
-    pub created_at: u64,
-    pub metadata: Map<Symbol, Vec<u8>>,
-}
 
-#[contracttype]
-pub struct Dispute {
-    pub escrow_id: BytesN<32>,
-    pub challenger: Address,
-    pub reason: Symbol,
-    pub evidence: Vec<u8>,
-    pub created_at: u64,
-    pub resolved: bool,
-}
+// ─── Contract ────────────────────────────────────────────────────────────────
 
 pub struct EscrowContract;
 
 #[contract]
 pub trait EscrowTrait {
+    /// One-time initialisation — sets the admin address.
+    /// Must be called before any other admin-gated function.
+    fn initialize(env: Env, admin: Address) -> bool;
+
     fn create_escrow(
         env: Env,
         sender: Address,
@@ -95,6 +121,23 @@ pub trait EscrowTrait {
 
 #[contractimpl]
 impl EscrowTrait for EscrowContract {
+    // ── initialize ──────────────────────────────────────────────────────────
+
+    fn initialize(env: Env, admin: Address) -> bool {
+        let init_key = Symbol::new(&env, INIT_KEY);
+        if env.storage().persistent().has(&init_key) {
+            panic!("Contract already initialized");
+        }
+        env.storage().persistent().set(&Symbol::new(&env, ADMIN_KEY), &admin);
+        env.storage().persistent().set(&init_key, &true);
+        true
+    }
+
+    // ── create_escrow ────────────────────────────────────────────────────────
+    //
+    // Transfers `amount` tokens from `sender` into the contract's own address,
+    // locking the funds until release or refund.
+
     fn create_escrow(
         env: Env,
         sender: Address,
@@ -106,13 +149,20 @@ impl EscrowTrait for EscrowContract {
     ) -> BytesN<32> {
         sender.require_auth();
 
-        let escrow_id = env.crypto().sha256(&(
-            sender.clone(),
-            receiver.clone(),
-            amount,
-            env.ledger().timestamp(),
-        )
-            .into());
+        assert!(amount > 0, "Amount must be positive");
+        assert!(
+            release_time > env.ledger().timestamp(),
+            "Release time must be in the future"
+        );
+
+        // ── Transfer tokens from sender → contract (lock funds) ──────────────
+        let token_client = TokenClient::new(&env, &token);
+        token_client.transfer(&sender, &env.current_contract_address(), &amount);
+
+        // ── Build and store escrow record ────────────────────────────────────
+        let escrow_id: BytesN<32> = env.crypto().sha256(
+            &(sender.clone(), receiver.clone(), amount, env.ledger().timestamp()).into(),
+        );
 
         let escrow = Escrow {
             id: escrow_id.clone(),
@@ -126,66 +176,116 @@ impl EscrowTrait for EscrowContract {
             metadata,
         };
 
-        let escrow_key = Symbol::new(&env, "ESCROW");
-        let mut escrows = env.storage().persistent().get::<_, Map<BytesN<32>, Escrow>>(&escrow_key)
+        let escrow_key = Symbol::new(&env, ESCROW_KEY);
+        let mut escrows = env
+            .storage()
+            .persistent()
+            .get::<_, Map<BytesN<32>, Escrow>>(&escrow_key)
             .unwrap_or_else(|| Map::new(&env));
         escrows.set(escrow_id.clone(), escrow);
         env.storage().persistent().set(&escrow_key, &escrows);
 
-        let user_escrows_key = Symbol::new(&env, &format!("USER_ESCROWS_{}", sender));
-        let mut user_escrows = env.storage().persistent().get::<_, Vec<BytesN<32>>>(&user_escrows_key)
+        // Index by sender for fast user-escrow lookup
+        let sender_key = (Symbol::new(&env, "USER_ESCROWS"), sender.clone());
+        let mut sender_escrows = env
+            .storage()
+            .persistent()
+            .get::<_, Vec<BytesN<32>>>(&sender_key)
             .unwrap_or_else(|| Vec::new(&env));
-        user_escrows.push_back(escrow_id.clone());
-        env.storage().persistent().set(&user_escrows_key, &user_escrows);
+        sender_escrows.push_back(escrow_id.clone());
+        env.storage().persistent().set(&sender_key, &sender_escrows);
+
+        // Also index by receiver
+        let receiver_key = (Symbol::new(&env, "USER_ESCROWS"), receiver.clone());
+        let mut receiver_escrows = env
+            .storage()
+            .persistent()
+            .get::<_, Vec<BytesN<32>>>(&receiver_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        receiver_escrows.push_back(escrow_id.clone());
+        env.storage().persistent().set(&receiver_key, &receiver_escrows);
 
         escrow_id
     }
 
+    // ── release_escrow ───────────────────────────────────────────────────────
+    //
+    // Receiver calls this after the time-lock expires.
+    // Transfers the held tokens from the contract → receiver.
+
     fn release_escrow(env: Env, escrow_id: BytesN<32>) -> bool {
-        let escrow_key = Symbol::new(&env, "ESCROW");
-        let mut escrows = env.storage().persistent().get::<_, Map<BytesN<32>, Escrow>>(&escrow_key)
+        let escrow_key = Symbol::new(&env, ESCROW_KEY);
+        let mut escrows = env
+            .storage()
+            .persistent()
+            .get::<_, Map<BytesN<32>, Escrow>>(&escrow_key)
             .unwrap_or_else(|| Map::new(&env));
-        
-        let mut escrow = escrows.get(escrow_id.clone())
+
+        let mut escrow = escrows
+            .get(escrow_id.clone())
             .unwrap_or_else(|| panic!("Escrow not found"));
 
-        if escrow.status != EscrowStatus::Pending {
-            panic!("Escrow is not in pending status");
-        }
-
-        if env.ledger().timestamp() < escrow.release_time {
-            panic!("Escrow is still time-locked");
-        }
+        assert!(
+            escrow.status == EscrowStatus::Pending,
+            "Escrow is not in pending status"
+        );
+        assert!(
+            env.ledger().timestamp() >= escrow.release_time,
+            "Escrow is still time-locked"
+        );
 
         escrow.receiver.require_auth();
 
+        // ── Transfer tokens: contract → receiver ─────────────────────────────
+        let token_client = TokenClient::new(&env, &escrow.token);
+        token_client.transfer(&env.current_contract_address(), &escrow.receiver, &escrow.amount);
+
         escrow.status = EscrowStatus::Completed;
-        escrows.set(escrow_id.clone(), escrow.clone());
+        escrows.set(escrow_id, escrow);
         env.storage().persistent().set(&escrow_key, &escrows);
 
         true
     }
 
+    // ── refund_escrow ────────────────────────────────────────────────────────
+    //
+    // Sender cancels the escrow before it's released.
+    // Transfers the held tokens from the contract → sender.
+
     fn refund_escrow(env: Env, escrow_id: BytesN<32>) -> bool {
-        let escrow_key = Symbol::new(&env, "ESCROW");
-        let mut escrows = env.storage().persistent().get::<_, Map<BytesN<32>, Escrow>>(&escrow_key)
+        let escrow_key = Symbol::new(&env, ESCROW_KEY);
+        let mut escrows = env
+            .storage()
+            .persistent()
+            .get::<_, Map<BytesN<32>, Escrow>>(&escrow_key)
             .unwrap_or_else(|| Map::new(&env));
-        
-        let mut escrow = escrows.get(escrow_id.clone())
+
+        let mut escrow = escrows
+            .get(escrow_id.clone())
             .unwrap_or_else(|| panic!("Escrow not found"));
 
-        if escrow.status != EscrowStatus::Pending {
-            panic!("Escrow is not in pending status");
-        }
+        assert!(
+            escrow.status == EscrowStatus::Pending,
+            "Escrow is not in pending status"
+        );
 
         escrow.sender.require_auth();
 
+        // ── Transfer tokens: contract → sender ──────────────────────────────
+        let token_client = TokenClient::new(&env, &escrow.token);
+        token_client.transfer(&env.current_contract_address(), &escrow.sender, &escrow.amount);
+
         escrow.status = EscrowStatus::Refunded;
-        escrows.set(escrow_id.clone(), escrow.clone());
+        escrows.set(escrow_id, escrow);
         env.storage().persistent().set(&escrow_key, &escrows);
 
         true
     }
+
+    // ── dispute_escrow ───────────────────────────────────────────────────────
+    //
+    // Either party can open a dispute while the escrow is Pending.
+    // Funds remain locked in the contract until resolve_dispute is called.
 
     fn dispute_escrow(
         env: Env,
@@ -196,26 +296,36 @@ impl EscrowTrait for EscrowContract {
     ) -> bool {
         challenger.require_auth();
 
-        let escrow_key = Symbol::new(&env, "ESCROW");
-        let mut escrows = env.storage().persistent().get::<_, Map<BytesN<32>, Escrow>>(&escrow_key)
+        let escrow_key = Symbol::new(&env, ESCROW_KEY);
+        let mut escrows = env
+            .storage()
+            .persistent()
+            .get::<_, Map<BytesN<32>, Escrow>>(&escrow_key)
             .unwrap_or_else(|| Map::new(&env));
-        
-        let mut escrow = escrows.get(escrow_id.clone())
+
+        let mut escrow = escrows
+            .get(escrow_id.clone())
             .unwrap_or_else(|| panic!("Escrow not found"));
 
-        if escrow.status != EscrowStatus::Pending {
-            panic!("Escrow is not in pending status");
-        }
+        assert!(
+            escrow.status == EscrowStatus::Pending,
+            "Escrow is not in pending status"
+        );
 
+        // Only sender or receiver may raise a dispute
+        assert!(
+            challenger == escrow.sender || challenger == escrow.receiver,
+            "Only escrow parties may dispute"
+        );
+
+        // Mark as disputed — tokens remain locked in the contract
         escrow.status = EscrowStatus::Disputed;
         escrows.set(escrow_id.clone(), escrow);
         env.storage().persistent().set(&escrow_key, &escrows);
 
-        let dispute_id = env.crypto().sha256(&(
-            escrow_id.clone(),
-            challenger.clone(),
-            env.ledger().timestamp(),
-        ).into());
+        let dispute_id: BytesN<32> = env.crypto().sha256(
+            &(escrow_id.clone(), challenger.clone(), env.ledger().timestamp()).into(),
+        );
 
         let dispute = Dispute {
             escrow_id: escrow_id.clone(),
@@ -226,65 +336,103 @@ impl EscrowTrait for EscrowContract {
             resolved: false,
         };
 
-        let disputes_key = Symbol::new(&env, "DISPUTES");
-        let mut disputes = env.storage().persistent().get::<_, Map<BytesN<32>, Dispute>>(&disputes_key)
+        let disputes_key = Symbol::new(&env, DISPUTES_KEY);
+        let mut disputes = env
+            .storage()
+            .persistent()
+            .get::<_, Map<BytesN<32>, Dispute>>(&disputes_key)
             .unwrap_or_else(|| Map::new(&env));
-        disputes.set(dispute_id.clone(), dispute);
+        disputes.set(dispute_id, dispute);
         env.storage().persistent().set(&disputes_key, &disputes);
 
         true
     }
+
+    // ── resolve_dispute ──────────────────────────────────────────────────────
+    //
+    // Admin-only. Transfers funds to the winning party:
+    //   - in_favor_of_challenger=true  → refund to sender (challenger or party 1)
+    //   - in_favor_of_challenger=false → release to receiver
 
     fn resolve_dispute(
         env: Env,
         dispute_id: BytesN<32>,
         in_favor_of_challenger: bool,
     ) -> bool {
-        let admin_key = Symbol::new(&env, "ADMIN");
-        let admin = env.storage().persistent().get::<_, Address>(&admin_key)
-            .unwrap_or_else(|| panic!("Admin not set"));
+        let admin_key = Symbol::new(&env, ADMIN_KEY);
+        let admin = env
+            .storage()
+            .persistent()
+            .get::<_, Address>(&admin_key)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         admin.require_auth();
 
-        let disputes_key = Symbol::new(&env, "DISPUTES");
-        let mut disputes = env.storage().persistent().get::<_, Map<BytesN<32>, Dispute>>(&disputes_key)
+        let disputes_key = Symbol::new(&env, DISPUTES_KEY);
+        let mut disputes = env
+            .storage()
+            .persistent()
+            .get::<_, Map<BytesN<32>, Dispute>>(&disputes_key)
             .unwrap_or_else(|| Map::new(&env));
-        
-        let mut dispute = disputes.get(dispute_id.clone())
+
+        let mut dispute = disputes
+            .get(dispute_id.clone())
             .unwrap_or_else(|| panic!("Dispute not found"));
 
-        if dispute.resolved {
-            panic!("Dispute already resolved");
-        }
+        assert!(!dispute.resolved, "Dispute already resolved");
 
         dispute.resolved = true;
         disputes.set(dispute_id.clone(), dispute.clone());
         env.storage().persistent().set(&disputes_key, &disputes);
 
-        let escrow_key = Symbol::new(&env, "ESCROW");
-        let mut escrows = env.storage().persistent().get::<_, Map<BytesN<32>, Escrow>>(&escrow_key)
+        let escrow_key = Symbol::new(&env, ESCROW_KEY);
+        let mut escrows = env
+            .storage()
+            .persistent()
+            .get::<_, Map<BytesN<32>, Escrow>>(&escrow_key)
             .unwrap_or_else(|| Map::new(&env));
-        
-        let mut escrow = escrows.get(dispute.escrow_id.clone())
+
+        let mut escrow = escrows
+            .get(dispute.escrow_id.clone())
             .unwrap_or_else(|| panic!("Escrow not found"));
 
-        escrow.status = if in_favor_of_challenger {
-            EscrowStatus::Refunded
-        } else {
-            EscrowStatus::Completed
-        };
+        let token_client = TokenClient::new(&env, &escrow.token);
 
-        escrows.set(dispute.escrow_id.clone(), escrow);
+        if in_favor_of_challenger {
+            // ── Refund locked tokens → sender ────────────────────────────────
+            token_client.transfer(
+                &env.current_contract_address(),
+                &escrow.sender,
+                &escrow.amount,
+            );
+            escrow.status = EscrowStatus::Refunded;
+        } else {
+            // ── Release locked tokens → receiver ─────────────────────────────
+            token_client.transfer(
+                &env.current_contract_address(),
+                &escrow.receiver,
+                &escrow.amount,
+            );
+            escrow.status = EscrowStatus::Completed;
+        }
+
+        escrows.set(dispute.escrow_id, escrow);
         env.storage().persistent().set(&escrow_key, &escrows);
 
         true
     }
 
+    // ── read-only queries ────────────────────────────────────────────────────
+
     fn get_escrow(env: Env, escrow_id: BytesN<32>) -> Escrow {
-        let escrow_key = Symbol::new(&env, "ESCROW");
-        let escrows = env.storage().persistent().get::<_, Map<BytesN<32>, Escrow>>(&escrow_key)
+        let escrow_key = Symbol::new(&env, ESCROW_KEY);
+        let escrows = env
+            .storage()
+            .persistent()
+            .get::<_, Map<BytesN<32>, Escrow>>(&escrow_key)
             .unwrap_or_else(|| Map::new(&env));
-        
-        escrows.get(escrow_id)
+
+        escrows
+            .get(escrow_id)
             .unwrap_or_else(|| panic!("Escrow not found"))
     }
 
@@ -293,20 +441,28 @@ impl EscrowTrait for EscrowContract {
     }
 
     fn get_dispute(env: Env, dispute_id: BytesN<32>) -> Dispute {
-        let disputes_key = Symbol::new(&env, "DISPUTES");
-        let disputes = env.storage().persistent().get::<_, Map<BytesN<32>, Dispute>>(&disputes_key)
+        let disputes_key = Symbol::new(&env, DISPUTES_KEY);
+        let disputes = env
+            .storage()
+            .persistent()
+            .get::<_, Map<BytesN<32>, Dispute>>(&disputes_key)
             .unwrap_or_else(|| Map::new(&env));
-        
-        disputes.get(dispute_id)
+
+        disputes
+            .get(dispute_id)
             .unwrap_or_else(|| panic!("Dispute not found"))
     }
 
     fn get_user_escrows(env: Env, user: Address) -> Vec<BytesN<32>> {
-        let user_escrows_key = Symbol::new(&env, &format!("USER_ESCROWS_{}", user));
-        env.storage().persistent().get::<_, Vec<BytesN<32>>>(&user_escrows_key)
+        let user_key = (Symbol::new(&env, "USER_ESCROWS"), user);
+        env.storage()
+            .persistent()
+            .get::<_, Vec<BytesN<32>>>(&user_key)
             .unwrap_or_else(|| Vec::new(&env))
     }
 }
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,5 @@ pub use compliance::{
     ComplianceCheck, ComplianceContract, ComplianceLevel, ComplianceRecord, RiskLevel,
     TransactionRule,
 };
-pub use escrow::{Dispute, Escrow, EscrowContract, EscrowStatus};
+pub use escrow::{Dispute, DisputeEvidence, Escrow, EscrowContract, EscrowStatus, get_evidence, store_evidence};
 pub use rate_oracle::{AggregatedRate, ExchangeRate, RateOracleContract, RateSource};


### PR DESCRIPTION


closes #113

closes #115

## Summary

Two critical gaps addressed.

### 1. Escrow contract — proper token custody (src/escrow.rs)

The contract previously stored escrow status only; no tokens ever moved.
Every state-changing function now calls TokenClient (SEP-41):

- create_escrow   — transfers sender → contract (locks funds on creation)
- release_escrow  — transfers contract → receiver (pays out on expiry)
- refund_escrow   — transfers contract → sender (returns funds on cancel)
- resolve_dispute — transfers to winning party based on admin ruling

Additional fixes bundled with the token work:
- Added #[contracttype] to Escrow/Dispute/DisputeEvidence (was missing; caused Soroban serialization failures)
- Added initialize(admin) one-time guard — prevents admin takeover race on first deploy
- dispute_escrow now requires challenger to be sender or receiver
- Input validation: amount > 0, release_time > now before any token movement
- USER_ESCROWS key uses tuple (Symbol, Address) instead of format!() (unavailable in no_std)

### 2. UI error states with retry (hooks + components)

hooks/useNotifications.ts — new hook:
- Typed notification store with error/warning/success/info and category tags (exchange_rate, compliance, payment, escrow)
- Domain helpers: notifyRateError, notifyComplianceError, notifyPaymentError — each accepts a retry callback
- retryNotification(id) awaits the callback, tracks attempt count, auto-dismisses on success
- Auto-dismiss timers for successes (5s), persistent for errors

components/NotificationCenter.tsx — bell + dropdown:
- Error cards with inline Retry button and animated spinner
- Collapsible error detail (raw message hidden by default)
- Unread badge on bell, clears on open; keyboard accessible

components/CommandPalette.tsx — ⌘K command modal:
- Each action's onSelect is awaited with inline loading spinner on the row
- On failure: Failed badge + Retry button on the row, red banner at top
- Failed actions forwarded to NotificationCenter as persistent notifications
- Full keyboard nav (↑↓ Enter Escape), ARIA roles
