### PR TITLE
Fix compliance panic, escrow refund time-lock, and RateOptimizer error reporting

### DIFF
--- a/sdk/src/rateOptimizer.test.ts
+++ b/sdk/src/rateOptimizer.test.ts
@@ -281,7 +281,7 @@ describe('RateOptimizer oracle rate precision', () => {
     expect(quote.confidence).toBe(50);
   });
 
-  it('returns null when getExchangeRate throws', async () => {
+  it('rethrows when getExchangeRate fails', async () => {
     const client    = new StellarClient(TEST_CONFIG, TEST_CONTRACTS);
     const optimizer = new RateOptimizer(client);
 
@@ -289,8 +289,7 @@ describe('RateOptimizer oracle rate precision', () => {
       new Error('rate not found')
     );
 
-    const quote = await (optimizer as any).getOracleQuote('EUR', 'USD', '100');
-    expect(quote).toBeNull();
+    await expect((optimizer as any).getOracleQuote('EUR', 'USD', '100')).rejects.toThrow('rate not found');
   });
 });
 
@@ -322,7 +321,7 @@ describe('RateOptimizer external venue (placeholder)', () => {
 describe('RateOptimizer DEX venue delegation', () => {
   afterEach(() => jest.restoreAllMocks());
 
-  it('returns null when PathPaymentService.findBestPath throws', async () => {
+  it('rethrows when PathPaymentService.findBestPath fails', async () => {
     const client    = new StellarClient(TEST_CONFIG, TEST_CONTRACTS);
     const optimizer = new RateOptimizer(client);
 
@@ -330,8 +329,7 @@ describe('RateOptimizer DEX venue delegation', () => {
       new Error('No path found')
     );
 
-    const quote = await (optimizer as any).getDexQuote(FROM, TO, AMT);
-    expect(quote).toBeNull();
+    await expect((optimizer as any).getDexQuote(FROM, TO, AMT)).rejects.toThrow('No path found');
   });
 
   it('maps the PathPaymentService result to an OptimizedRate with venue DEX', async () => {

--- a/sdk/src/rateOptimizer.ts
+++ b/sdk/src/rateOptimizer.ts
@@ -115,10 +115,21 @@ export class RateOptimizer {
     const fromSymbol = this.getAssetSymbol(fromAsset);
     const toSymbol   = this.getAssetSymbol(toAsset);
 
+    const failures: { venue: string; reason: string }[] = [];
+
     const [dexQuote, oracleQuote, externalQuote] = await Promise.all([
-      this.getDexQuote(fromAsset, toAsset, amount),
-      this.getOracleQuote(fromSymbol, toSymbol, amount),
-      this.getExternalQuote(fromSymbol, toSymbol, amount),
+      this.getDexQuote(fromAsset, toAsset, amount).catch((e: Error) => {
+        failures.push({ venue: 'DEX', reason: e.message });
+        return null;
+      }),
+      this.getOracleQuote(fromSymbol, toSymbol, amount).catch((e: Error) => {
+        failures.push({ venue: 'Oracle', reason: e.message });
+        return null;
+      }),
+      this.getExternalQuote(fromSymbol, toSymbol, amount).catch((e: Error) => {
+        failures.push({ venue: 'External', reason: e.message });
+        return null;
+      }),
     ]);
 
     const quotes: OptimizedRate[] = [];
@@ -127,7 +138,10 @@ export class RateOptimizer {
     if (externalQuote) quotes.push(externalQuote);
 
     if (quotes.length === 0) {
-      throw new Error(`No execution path found for ${fromAsset} -> ${toAsset}`);
+      const details = failures.map(f => `${f.venue}: ${f.reason}`).join('; ');
+      throw new Error(
+        `No execution path found for ${fromAsset} -> ${toAsset}. Failures: ${details}`
+      );
     }
 
     // Sort by best rate (highest amount for destination)
@@ -148,21 +162,17 @@ export class RateOptimizer {
     to: string,
     amount: string
   ): Promise<OptimizedRate | null> {
-    try {
-      const fromA   = this.parseAsset(from);
-      const toA     = this.parseAsset(to);
-      const result: BestPathResult = await this.pathService.findBestPath(fromA, toA, amount);
+    const fromA   = this.parseAsset(from);
+    const toA     = this.parseAsset(to);
+    const result: BestPathResult = await this.pathService.findBestPath(fromA, toA, amount);
 
-      return {
-        venue:      'DEX',
-        rate:       result.rate.toString(),
-        amount:     result.destinationAmount,
-        path:       result.path,
-        confidence: 95,
-      };
-    } catch {
-      return null;
-    }
+    return {
+      venue:      'DEX',
+      rate:       result.rate.toString(),
+      amount:     result.destinationAmount,
+      path:       result.path,
+      confidence: 95,
+    };
   }
 
   /**
@@ -180,25 +190,21 @@ export class RateOptimizer {
     to: number | string,
     amount: string
   ): Promise<OptimizedRate | null> {
-    try {
-      const request: ExchangeRateRequest = {
-        from_currency: from,
-        to_currency:   to.toString(),
-      };
-      const result = await this.payments.getExchangeRate(request);
+    const request: ExchangeRateRequest = {
+      from_currency: from,
+      to_currency:   to.toString(),
+    };
+    const result = await this.payments.getExchangeRate(request);
 
-      const rateBN    = new BigNumber(result.rate).dividedBy(1_000_000);
-      const destAmount = new BigNumber(amount).times(rateBN).toFixed(7);
+    const rateBN    = new BigNumber(result.rate).dividedBy(1_000_000);
+    const destAmount = new BigNumber(amount).times(rateBN).toFixed(7);
 
-      return {
-        venue:      'Oracle',
-        rate:       rateBN.toString(),
-        amount:     destAmount,
-        confidence: result.aggregated.sources_count > 0 ? 90 : 50,
-      };
-    } catch {
-      return null;
-    }
+    return {
+      venue:      'Oracle',
+      rate:       rateBN.toString(),
+      amount:     destAmount,
+      confidence: result.aggregated.sources_count > 0 ? 90 : 50,
+    };
   }
 
   /**

--- a/src/compliance.rs
+++ b/src/compliance.rs
@@ -221,10 +221,42 @@ impl ComplianceTrait for ComplianceContract {
         let records = env.storage().persistent().get::<_, Map<Address, ComplianceRecord>>(&records_key)
             .unwrap_or_else(|| Map::new(&env));
 
-        let from_record = records.get(from_user.clone())
-            .unwrap_or_else(|| panic!("Sender not registered"));
-        let to_record = records.get(to_user.clone())
-            .unwrap_or_else(|| panic!("Receiver not registered"));
+        let from_record = match records.get(from_user.clone()) {
+            Some(record) => record,
+            None => {
+                return ComplianceCheck {
+                    transaction_id,
+                    from_user: from_user.clone(),
+                    to_user: to_user.clone(),
+                    amount,
+                    currency,
+                    jurisdiction_from,
+                    jurisdiction_to,
+                    timestamp: env.ledger().timestamp(),
+                    approved: false,
+                    reason: Symbol::new(&env, "SENDER_NOT_REGISTERED"),
+                    rules_triggered: Vec::new(&env),
+                };
+            }
+        };
+        let to_record = match records.get(to_user.clone()) {
+            Some(record) => record,
+            None => {
+                return ComplianceCheck {
+                    transaction_id,
+                    from_user,
+                    to_user,
+                    amount,
+                    currency,
+                    jurisdiction_from,
+                    jurisdiction_to,
+                    timestamp: env.ledger().timestamp(),
+                    approved: false,
+                    reason: Symbol::new(&env, "RECEIVER_NOT_REGISTERED"),
+                    rules_triggered: Vec::new(&env),
+                };
+            }
+        };
 
         if from_record.risk_level == RiskLevel::Restricted || to_record.risk_level == RiskLevel::Restricted {
             return ComplianceCheck {

--- a/src/escrow.rs
+++ b/src/escrow.rs
@@ -277,6 +277,11 @@ impl EscrowTrait for EscrowContract {
             "Escrow is not in pending status"
         );
 
+        assert!(
+            escrow.release_time <= env.ledger().timestamp(),
+            "Escrow is still time-locked"
+        );
+
         escrow.sender.require_auth();
 
         // ── Transfer tokens: contract → sender ──────────────────────────────


### PR DESCRIPTION
## Summary

Three fixes to improve contract robustness and developer experience:

### 1. Compliance contract: replace panics with structured responses (#121)
`check_transaction_compliance` no longer panics when sender or receiver is unregistered. Returns a `ComplianceCheck` with `approved: false` and reason `SENDER_NOT_REGISTERED` or `RECEIVER_NOT_REGISTERED` so contract clients can handle unregistered users gracefully.

### 2. Escrow refund: enforce time-lock (#117)
`refund_escrow` now checks that `release_time <= current_timestamp`, preventing premature refunds before the time-lock expires. This ensures the receiver's lock-in window is respected.

### 3. RateOptimizer: surface failure reasons (#104)
`findCheapestExecution` now collects error messages from each venue when quotes fail and includes them in the thrown error when all venues fail (e.g. `No execution path found for X -> Y. Failures: DEX: No path found; Oracle: rate not found`).

Closes #121
Closes #117
Closes #104