### PR TITLE
Feat/issue 32 json validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ A comprehensive SDK for building cross-border payment applications on the Stella
 - [TypeScript SDK](#typescript-sdk)
 - [React Components](#react-components)
 - [Examples](#examples)
+- [CLI Tool](#-cli-tool-stellar-payout)
+- [Status Monitoring](#-status-monitoring)
 - [Configuration](#️-configuration)
 - [API Reference](#api-reference)
 - [Building](#building)
@@ -481,18 +483,121 @@ stellar-payout batch --input payments.csv --source-secret $SECRET_KEY \
   --network testnet
 ```
 
-#### `stellar-payout status` - Real-Time Monitoring
+#### `stellar-payout status` - Batch Status Monitoring
+
+Query the state of any batch and optionally stream live updates while it runs.
+
+**Options**
+
+| Flag | Env var | Default | Description |
+|---|---|---|---|
+| `-b, --batch-id <id>` | — | _(omit to list recent)_ | Batch ID to inspect. Omit to show the 10 most recent batches. |
+| `-f, --follow` | — | `false` | Stream live progress updates until the batch finishes (Ctrl+C to stop). Only active while the batch status is `running`. |
+| `--horizon-url <url>` | `HORIZON_URL` | `https://horizon-testnet.stellar.org` | Horizon endpoint used for Horizon transaction streaming when `--follow` is set. |
+| `--db-path <path>` | `DB_PATH` | `./stellar-payout.db` | Path to the SQLite database written by `stellar-payout batch`. Must point to the same file used during batch processing. |
+| `--verbose` | — | `false` | Print debug output including the Horizon stream endpoint. |
+
+**Usage examples**
 
 ```bash
-# Show recent batches
+# List the 10 most recent batches across all runs
 stellar-payout status
 
-# Monitor specific batch
-stellar-payout status --batch-id <batch_id>
+# Inspect a specific batch (snapshot, no streaming)
+stellar-payout status --batch-id batch_1735000000000_abc123
 
-# Stream real-time updates via Horizon
-stellar-payout status --batch-id <batch_id> --follow
+# Stream live progress while the batch is running (polls every 2 s,
+# also tails new Horizon transactions every 5 s)
+stellar-payout status --batch-id batch_1735000000000_abc123 --follow
+
+# Use a non-default database path (must match the path passed to batch)
+stellar-payout status --batch-id batch_1735000000000_abc123 \
+  --db-path /data/payroll.db
+
+# Point at mainnet Horizon when streaming a mainnet batch
+stellar-payout status --batch-id batch_1735000000000_abc123 --follow \
+  --horizon-url https://horizon.stellar.org \
+  --db-path ./mainnet-payout.db
+
+# Verbose mode — prints the Horizon stream URL and debug info
+stellar-payout status --batch-id batch_1735000000000_abc123 --follow --verbose
 ```
+
+**Output — batch summary table**
+
+When a batch ID is provided, the command prints a property/value table:
+
+```
+┌─────────────────┬────────────────────────────────────────────┐
+│ Property        │ Value                                      │
+├─────────────────┼────────────────────────────────────────────┤
+│ Batch ID        │ batch_1735000000000_abc123                  │
+│ Status          │ completed                                   │
+│ Network         │ testnet                                     │
+│ Source Account  │ GABC...XYZ                                  │
+│ Total Payments  │ 50                                          │
+│ Processed       │ 50                                          │
+│ Successful      │ 48                                          │
+│ Failed          │ 2                                           │
+│ Skipped         │ 0                                           │
+│ Started At      │ 2024-01-15T09:00:00.000Z                    │
+│ Completed At    │ 2024-01-15T09:04:37.000Z                    │
+│ Dry Run         │ No                                          │
+└─────────────────┴────────────────────────────────────────────┘
+```
+
+It then shows a per-status breakdown of payment entries, full details of any failed entries (up to 20), and a transaction-group table.
+
+**Output — recent batches list (no batch ID)**
+
+```
+┌──────────────────────────────┬───────────┬───────┬─────────┬────────┬─────────┬──────────────────────────┐
+│ Batch ID                     │ Status    │ Total │ Success │ Failed │ Network │ Started                  │
+├──────────────────────────────┼───────────┼───────┼─────────┼────────┼─────────┼──────────────────────────┤
+│ batch_1735000000000_abc123   │ completed │ 50    │ 48      │ 2      │ testnet │ 2024-01-15T09:00:00.000Z │
+│ batch_1734900000000_def456   │ failed    │ 10    │ 0       │ 10     │ testnet │ 2024-01-14T14:22:00.000Z │
+└──────────────────────────────┴───────────┴───────┴─────────┴────────┴─────────┴──────────────────────────┘
+```
+
+**Interpreting batch and entry statuses**
+
+*Batch statuses*
+
+| Status | Meaning |
+|---|---|
+| `created` | Batch initialised but not yet started. |
+| `running` | Actively submitting transactions. |
+| `paused` | Gracefully paused by SIGINT — safe to resume with `retry`. |
+| `completed` | All entries reached a terminal state (confirmed, failed, or skipped). |
+| `failed` | Batch encountered a fatal error and stopped. |
+| `cancelled` | Manually cancelled. |
+
+*Entry statuses*
+
+| Status | Meaning |
+|---|---|
+| `pending` | Not yet picked up for submission. |
+| `validating` | Destination account and trustline checks in progress. |
+| `submitted` | Transaction sent to Horizon, awaiting ledger confirmation. |
+| `confirmed` | Transaction included in a ledger — payment delivered. |
+| `failed` | Submission or confirmation failed. See the `Error` column for details. Use `stellar-payout retry` to resubmit. |
+| `retrying` | Queued for automatic retry with exponential backoff. |
+| `skipped` | Entry excluded (e.g. destination has no trustline and validation failed). |
+
+**`--follow` streaming behaviour**
+
+When `--follow` is passed and the batch status is `running`, the command:
+
+1. Polls the local SQLite database every **2 seconds** and prints a progress bar whenever the processed count changes.
+2. Simultaneously polls the Horizon `/accounts/{sourceAccount}/transactions` endpoint every **5 seconds**, printing each new transaction hash and its operation count as it lands on-chain.
+3. Exits automatically when the batch status transitions to `completed`, `failed`, or `cancelled`.
+4. Stops cleanly on **Ctrl+C** (SIGINT).
+
+If the batch is already in a terminal status when `--follow` is supplied, the snapshot is printed and the command exits immediately — no streaming occurs.
+
+> **Database path**: `--follow` reads from the same SQLite file the `batch` command writes to. If the batch is running on another machine or in a container, mount or copy the database file to a path accessible locally, then pass it via `--db-path`.
+
+> **Horizon URL**: The streaming poller uses the `--horizon-url` value (or `HORIZON_URL` env var). For mainnet batches, ensure this is set to `https://horizon.stellar.org` or your own Horizon instance, otherwise the transaction tail will be empty.
 
 #### `stellar-payout retry` - Retry Failed Transactions
 
@@ -602,6 +707,94 @@ The `retry` command re-submits every entry whose status is `failed`.
 For entries stuck in `submitted` (submitted to Horizon but not yet confirmed),
 re-running the batch command with the same `--db-path` will detect the incomplete
 groups via `getIncompleteGroups` and re-check Horizon for their status.
+
+## 📊 Status Monitoring
+
+The `stellar-payout status` command is your primary window into any batch — whether it finished hours ago or is actively running right now.
+
+### Listing recent batches
+
+Running `status` without a batch ID shows the 10 most recent batches:
+
+```bash
+stellar-payout status
+```
+
+This is the quickest way to find a batch ID if you did not capture it from the `batch` command's output.
+
+### Inspecting a specific batch
+
+```bash
+stellar-payout status --batch-id batch_1735000000000_abc123
+```
+
+Prints a full summary: overall counters, a per-status breakdown of payment entries, details for any failed entries, and the transaction-group table.
+
+### Streaming live progress with `--follow`
+
+```bash
+stellar-payout status --batch-id batch_1735000000000_abc123 --follow
+```
+
+Attaches to a running batch and streams two sources of updates simultaneously:
+
+- **Local DB poll** (every 2 s) — progress bar showing confirmed / failed / skipped counts.
+- **Horizon transaction tail** (every 5 s) — prints each new transaction hash and operation count as it lands on-chain.
+
+The command exits automatically when the batch completes. Press **Ctrl+C** to detach early without affecting the running batch.
+
+### Using a custom database path
+
+The `batch` command writes state to `./stellar-payout.db` by default. If you passed a custom `--db-path` when running the batch, pass the same path to `status`:
+
+```bash
+# Batch was started with a custom DB path
+stellar-payout batch --input payments.csv --source-secret $SECRET_KEY \
+  --db-path /data/payroll-2024-01.db
+
+# Query that same batch
+stellar-payout status --db-path /data/payroll-2024-01.db
+
+# Monitor a specific batch in that file
+stellar-payout status --batch-id batch_1735000000000_abc123 \
+  --db-path /data/payroll-2024-01.db --follow
+```
+
+### Pointing at the correct Horizon instance
+
+The `--follow` poller connects to Horizon to tail live transactions. Make sure the URL matches the network the batch was submitted to:
+
+```bash
+# Testnet (default)
+stellar-payout status --batch-id <id> --follow
+# equivalent to:
+stellar-payout status --batch-id <id> --follow \
+  --horizon-url https://horizon-testnet.stellar.org
+
+# Mainnet
+stellar-payout status --batch-id <id> --follow \
+  --horizon-url https://horizon.stellar.org
+
+# Self-hosted / custom Horizon
+stellar-payout status --batch-id <id> --follow \
+  --horizon-url https://horizon.my-org.internal
+```
+
+Set `HORIZON_URL` in your `.env` to avoid repeating the flag on every run.
+
+### Interpreting the results
+
+**Batch is `completed`** — all entries reached a terminal state. Check `Failed` count; if > 0, run `stellar-payout report` for a full audit trail and `stellar-payout retry` to resubmit failures.
+
+**Batch is `running`** — use `--follow` to watch it live or re-run `status` periodically.
+
+**Batch is `paused`** — stopped by Ctrl+C during a previous run. Use `stellar-payout retry` to resume failed entries, or re-run `stellar-payout batch` with `--db-path` pointing to the same file to resume pending ones.
+
+**Batch is `failed`** — a fatal error stopped the batch. Check the `Error` column in the failed entries table, fix the root cause, then retry with `stellar-payout retry`.
+
+**Entry is `submitted` but batch is `completed`** — the transaction was sent to Horizon but confirmation was not recorded (e.g. a crash between Horizon confirm and DB write). Re-running `stellar-payout batch` with the same `--db-path` will re-check these entries against Horizon.
+
+**Entry is `skipped`** — destination account did not exist on-chain or lacked the required trustline at validation time. Verify the destination address and asset issuer, then retry.
 
 ## ⚙️ Configuration
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -13,7 +13,6 @@
     "start": "node dist/index.js",
     "test": "jest --runInBand",
     "lint": "eslint src/**/*.ts",
-    "test": "echo \"No tests yet\" && exit 0",
     "clean": "rimraf dist",
     "prepublishOnly": "npm run build"
   },

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -96,12 +96,33 @@ program
 // ── status command ───────────────────────────────────────────────────
 program
   .command('status')
-  .description('Real-time monitoring of batch payment status with Horizon streaming')
-  .option('-b, --batch-id <id>', 'Batch ID to monitor (shows recent batches if omitted)')
-  .option('-f, --follow', 'Stream real-time updates', false)
-  .option('--horizon-url <url>', 'Horizon URL (or HORIZON_URL)', envDefault('HORIZON_URL', DEFAULT_HORIZON_URL))
-  .option('--db-path <path>', 'SQLite database path (or DB_PATH)', envDefault('DB_PATH', DEFAULT_DB_PATH))
-  .option('--verbose', 'Enable verbose logging', false)
+  .description(
+    'Query batch payment status from the local database.\n' +
+    '  Omit --batch-id to list the 10 most recent batches.\n' +
+    '  Use --follow to stream live progress while a batch is running.\n\n' +
+    '  Examples:\n' +
+    '    stellar-payout status\n' +
+    '    stellar-payout status --batch-id <id>\n' +
+    '    stellar-payout status --batch-id <id> --follow\n' +
+    '    stellar-payout status --batch-id <id> --follow --horizon-url https://horizon.stellar.org'
+  )
+  .option('-b, --batch-id <id>', 'Batch ID to inspect (omit to list 10 most recent batches)')
+  .option(
+    '-f, --follow',
+    'Stream live updates: polls the local DB every 2 s and Horizon every 5 s until the batch completes (Ctrl+C to stop)',
+    false,
+  )
+  .option(
+    '--horizon-url <url>',
+    'Horizon endpoint used for transaction streaming with --follow (or HORIZON_URL)',
+    envDefault('HORIZON_URL', DEFAULT_HORIZON_URL),
+  )
+  .option(
+    '--db-path <path>',
+    'Path to the SQLite database written by "stellar-payout batch" — must match the path used when the batch was started (or DB_PATH)',
+    envDefault('DB_PATH', DEFAULT_DB_PATH),
+  )
+  .option('--verbose', 'Print debug output including the Horizon stream endpoint', false)
   .action(async (opts) => {
     if (opts.verbose) {
       setLogLevel(LogLevel.DEBUG);

--- a/cli/src/parsers/csv-parser.test.ts
+++ b/cli/src/parsers/csv-parser.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for the CSV parser.
+ *
+ * Uses temp files to remain self-contained without fixture files on disk.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { parseCSV } from './csv-parser';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeTempCSV(content: string): string {
+  const tmpFile = path.join(
+    os.tmpdir(),
+    `csv-test-${Date.now()}-${Math.random().toString(36).slice(2)}.csv`,
+  );
+  fs.writeFileSync(tmpFile, content, 'utf-8');
+  return tmpFile;
+}
+
+function parseCSVString(content: string) {
+  const file = writeTempCSV(content);
+  try {
+    return parseCSV(file);
+  } finally {
+    fs.unlinkSync(file);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sample inputs
+// ---------------------------------------------------------------------------
+
+const VALID_CSV = `destination,amount,asset,asset_issuer,memo,escrow_duration
+GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2,100,USDC,GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN,Invoice-001,3600
+GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGVA2XM9DWBF32LLVBF3,50,XLM,,Payroll,0`;
+
+const MINIMAL_CSV = `destination,amount
+GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2,200`;
+
+const EMPTY_ROWS_CSV = `destination,amount,asset,asset_issuer,memo,escrow_duration
+GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2,10,XLM,,,0
+
+GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGVA2XM9DWBF32LLVBF3,20,XLM,,,0`;
+
+const WHITESPACE_CSV = `destination , amount , asset
+  GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2 , 75 , XLM`;
+
+const MISSING_OPTIONAL_FIELDS_CSV = `destination,amount
+GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2,99`;
+
+const ESCROW_DURATION_CSV = `destination,amount,asset,asset_issuer,memo,escrow_duration
+GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2,50,XLM,,,7200`;
+
+const INVALID_ESCROW_CSV = `destination,amount,asset,asset_issuer,memo,escrow_duration
+GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2,50,XLM,,,notanumber`;
+
+// ---------------------------------------------------------------------------
+// Tests — valid inputs
+// ---------------------------------------------------------------------------
+
+describe('parseCSV — valid inputs', () => {
+  it('returns one PaymentRecord per data row', () => {
+    const records = parseCSVString(VALID_CSV);
+    expect(records).toHaveLength(2);
+  });
+
+  it('maps destination correctly', () => {
+    const [first] = parseCSVString(VALID_CSV);
+    expect(first.destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+  });
+
+  it('maps amount as a string', () => {
+    const [first] = parseCSVString(VALID_CSV);
+    expect(first.amount).toBe('100');
+  });
+
+  it('maps asset correctly', () => {
+    const [first] = parseCSVString(VALID_CSV);
+    expect(first.asset).toBe('USDC');
+  });
+
+  it('maps asset_issuer correctly', () => {
+    const [first] = parseCSVString(VALID_CSV);
+    expect(first.asset_issuer).toBe('GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN');
+  });
+
+  it('maps memo correctly', () => {
+    const [first] = parseCSVString(VALID_CSV);
+    expect(first.memo).toBe('Invoice-001');
+  });
+
+  it('maps escrow_duration as a number', () => {
+    const [first] = parseCSVString(VALID_CSV);
+    expect(first.escrow_duration).toBe(3600);
+  });
+
+  it('maps second row independently', () => {
+    const [, second] = parseCSVString(VALID_CSV);
+    expect(second.destination).toBe('GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGVA2XM9DWBF32LLVBF3');
+    expect(second.amount).toBe('50');
+    expect(second.asset).toBe('XLM');
+    expect(second.escrow_duration).toBe(0);
+  });
+
+  it('parses escrow_duration as integer', () => {
+    const [record] = parseCSVString(ESCROW_DURATION_CSV);
+    expect(record.escrow_duration).toBe(7200);
+    expect(typeof record.escrow_duration).toBe('number');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — default / fallback values
+// ---------------------------------------------------------------------------
+
+describe('parseCSV — default values for missing optional fields', () => {
+  it('defaults asset to XLM when column is absent', () => {
+    const [record] = parseCSVString(MISSING_OPTIONAL_FIELDS_CSV);
+    expect(record.asset).toBe('XLM');
+  });
+
+  it('defaults asset_issuer to empty string when column is absent', () => {
+    const [record] = parseCSVString(MISSING_OPTIONAL_FIELDS_CSV);
+    expect(record.asset_issuer).toBe('');
+  });
+
+  it('defaults memo to empty string when column is absent', () => {
+    const [record] = parseCSVString(MISSING_OPTIONAL_FIELDS_CSV);
+    expect(record.memo).toBe('');
+  });
+
+  it('defaults escrow_duration to 0 when column is absent', () => {
+    const [record] = parseCSVString(MISSING_OPTIONAL_FIELDS_CSV);
+    expect(record.escrow_duration).toBe(0);
+  });
+
+  it('defaults amount to "0" when amount column is absent', () => {
+    const csv = `destination\nGBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2`;
+    const [record] = parseCSVString(csv);
+    expect(record.amount).toBe('0');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — edge cases
+// ---------------------------------------------------------------------------
+
+describe('parseCSV — edge cases', () => {
+  it('skips empty lines', () => {
+    const records = parseCSVString(EMPTY_ROWS_CSV);
+    expect(records).toHaveLength(2);
+  });
+
+  it('trims whitespace from values', () => {
+    const [record] = parseCSVString(WHITESPACE_CSV);
+    expect(record.destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+    expect(record.amount).toBe('75');
+    expect(record.asset).toBe('XLM');
+  });
+
+  it('treats non-numeric escrow_duration as 0', () => {
+    const [record] = parseCSVString(INVALID_ESCROW_CSV);
+    expect(record.escrow_duration).toBe(0);
+  });
+
+  it('returns an empty array for a header-only CSV', () => {
+    const headerOnly = `destination,amount,asset,asset_issuer,memo,escrow_duration`;
+    const records = parseCSVString(headerOnly);
+    expect(records).toHaveLength(0);
+  });
+
+  it('returns all required PaymentRecord keys on every record', () => {
+    const records = parseCSVString(VALID_CSV);
+    for (const record of records) {
+      expect(record).toHaveProperty('destination');
+      expect(record).toHaveProperty('amount');
+      expect(record).toHaveProperty('asset');
+      expect(record).toHaveProperty('asset_issuer');
+      expect(record).toHaveProperty('memo');
+      expect(record).toHaveProperty('escrow_duration');
+    }
+  });
+
+  it('throws when the file does not exist', () => {
+    expect(() => parseCSV('/nonexistent/path/file.csv')).toThrow();
+  });
+});

--- a/cli/src/parsers/json-parser.test.ts
+++ b/cli/src/parsers/json-parser.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for the JSON parser.
+ *
+ * Uses temp files to remain self-contained without fixture files on disk.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { parseJSON } from './json-parser';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeTempJSON(content: string): string {
+  const tmpFile = path.join(
+    os.tmpdir(),
+    `json-test-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+  );
+  fs.writeFileSync(tmpFile, content, 'utf-8');
+  return tmpFile;
+}
+
+function parseJSONString(content: string) {
+  const file = writeTempJSON(content);
+  try {
+    return parseJSON(file);
+  } finally {
+    fs.unlinkSync(file);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sample inputs
+// ---------------------------------------------------------------------------
+
+const ARRAY_FORMAT = JSON.stringify([
+  {
+    destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2',
+    amount: '150',
+    asset: 'USDC',
+    asset_issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+    memo: 'Invoice-007',
+    escrow_duration: 3600,
+  },
+  {
+    destination: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGVA2XM9DWBF32LLVBF3',
+    amount: 75,
+    asset: 'XLM',
+    asset_issuer: '',
+    memo: '',
+    escrow_duration: 0,
+  },
+]);
+
+const OBJECT_WRAPPER_FORMAT = JSON.stringify({
+  payments: [
+    {
+      destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2',
+      amount: '200',
+      asset: 'EURC',
+      memo: 'Payroll-Q1',
+    },
+  ],
+});
+
+const NUMERIC_AMOUNT_FORMAT = JSON.stringify([
+  { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: 42 },
+]);
+
+const MISSING_OPTIONAL_FIELDS = JSON.stringify([
+  { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '10' },
+]);
+
+const EMPTY_ARRAY = JSON.stringify([]);
+
+const EMPTY_PAYMENTS_WRAPPER = JSON.stringify({ payments: [] });
+
+// ---------------------------------------------------------------------------
+// Tests — array format
+// ---------------------------------------------------------------------------
+
+describe('parseJSON — top-level array format', () => {
+  it('returns one record per array entry', () => {
+    const records = parseJSONString(ARRAY_FORMAT);
+    expect(records).toHaveLength(2);
+  });
+
+  it('maps destination correctly', () => {
+    const [first] = parseJSONString(ARRAY_FORMAT);
+    expect(first.destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+  });
+
+  it('maps string amount correctly', () => {
+    const [first] = parseJSONString(ARRAY_FORMAT);
+    expect(first.amount).toBe('150');
+  });
+
+  it('coerces numeric amount to string', () => {
+    const [, second] = parseJSONString(ARRAY_FORMAT);
+    expect(second.amount).toBe('75');
+    expect(typeof second.amount).toBe('string');
+  });
+
+  it('maps asset correctly', () => {
+    const [first] = parseJSONString(ARRAY_FORMAT);
+    expect(first.asset).toBe('USDC');
+  });
+
+  it('maps asset_issuer correctly', () => {
+    const [first] = parseJSONString(ARRAY_FORMAT);
+    expect(first.asset_issuer).toBe('GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN');
+  });
+
+  it('maps memo correctly', () => {
+    const [first] = parseJSONString(ARRAY_FORMAT);
+    expect(first.memo).toBe('Invoice-007');
+  });
+
+  it('maps escrow_duration correctly', () => {
+    const [first] = parseJSONString(ARRAY_FORMAT);
+    expect(first.escrow_duration).toBe(3600);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — { payments: [...] } wrapper format
+// ---------------------------------------------------------------------------
+
+describe('parseJSON — object wrapper { payments: [...] } format', () => {
+  it('reads entries from the payments key', () => {
+    const records = parseJSONString(OBJECT_WRAPPER_FORMAT);
+    expect(records).toHaveLength(1);
+  });
+
+  it('maps fields from wrapped format correctly', () => {
+    const [record] = parseJSONString(OBJECT_WRAPPER_FORMAT);
+    expect(record.destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+    expect(record.amount).toBe('200');
+    expect(record.asset).toBe('EURC');
+    expect(record.memo).toBe('Payroll-Q1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — default / fallback values
+// ---------------------------------------------------------------------------
+
+describe('parseJSON — default values for missing optional fields', () => {
+  it('defaults asset to XLM', () => {
+    const [record] = parseJSONString(MISSING_OPTIONAL_FIELDS);
+    expect(record.asset).toBe('XLM');
+  });
+
+  it('defaults asset_issuer to empty string', () => {
+    const [record] = parseJSONString(MISSING_OPTIONAL_FIELDS);
+    expect(record.asset_issuer).toBe('');
+  });
+
+  it('defaults memo to empty string', () => {
+    const [record] = parseJSONString(MISSING_OPTIONAL_FIELDS);
+    expect(record.memo).toBe('');
+  });
+
+  it('defaults escrow_duration to 0', () => {
+    const [record] = parseJSONString(MISSING_OPTIONAL_FIELDS);
+    expect(record.escrow_duration).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — numeric amount coercion
+// ---------------------------------------------------------------------------
+
+describe('parseJSON — numeric amount coercion', () => {
+  it('converts numeric amount to string', () => {
+    const [record] = parseJSONString(NUMERIC_AMOUNT_FORMAT);
+    expect(record.amount).toBe('42');
+    expect(typeof record.amount).toBe('string');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — edge cases
+// ---------------------------------------------------------------------------
+
+describe('parseJSON — edge cases', () => {
+  it('returns empty array for an empty top-level array', () => {
+    expect(parseJSONString(EMPTY_ARRAY)).toHaveLength(0);
+  });
+
+  it('returns empty array for an empty payments wrapper', () => {
+    expect(parseJSONString(EMPTY_PAYMENTS_WRAPPER)).toHaveLength(0);
+  });
+
+  it('returns all required PaymentRecord keys on every record', () => {
+    const records = parseJSONString(ARRAY_FORMAT);
+    for (const record of records) {
+      expect(record).toHaveProperty('destination');
+      expect(record).toHaveProperty('amount');
+      expect(record).toHaveProperty('asset');
+      expect(record).toHaveProperty('asset_issuer');
+      expect(record).toHaveProperty('memo');
+      expect(record).toHaveProperty('escrow_duration');
+    }
+  });
+
+  it('throws on malformed JSON', () => {
+    expect(() => parseJSONString('{ invalid json')).toThrow();
+  });
+
+  it('throws when the file does not exist', () => {
+    expect(() => parseJSON('/nonexistent/path/file.json')).toThrow();
+  });
+});

--- a/cli/src/parsers/json-parser.test.ts
+++ b/cli/src/parsers/json-parser.test.ts
@@ -35,24 +35,25 @@ function parseJSONString(content: string) {
 // Sample inputs
 // ---------------------------------------------------------------------------
 
-const ARRAY_FORMAT = JSON.stringify([
-  {
-    destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2',
-    amount: '150',
-    asset: 'USDC',
-    asset_issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
-    memo: 'Invoice-007',
-    escrow_duration: 3600,
-  },
-  {
-    destination: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGVA2XM9DWBF32LLVBF3',
-    amount: 75,
-    asset: 'XLM',
-    asset_issuer: '',
-    memo: '',
-    escrow_duration: 0,
-  },
-]);
+const VALID_ENTRY_1 = {
+  destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2',
+  amount: '150',
+  asset: 'USDC',
+  asset_issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+  memo: 'Invoice-007',
+  escrow_duration: 3600,
+};
+
+const VALID_ENTRY_2 = {
+  destination: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGVA2XM9DWBF32LLVBF3',
+  amount: 75,
+  asset: 'XLM',
+  asset_issuer: '',
+  memo: '',
+  escrow_duration: 0,
+};
+
+const ARRAY_FORMAT = JSON.stringify([VALID_ENTRY_1, VALID_ENTRY_2]);
 
 const OBJECT_WRAPPER_FORMAT = JSON.stringify({
   payments: [
@@ -65,62 +66,70 @@ const OBJECT_WRAPPER_FORMAT = JSON.stringify({
   ],
 });
 
-const NUMERIC_AMOUNT_FORMAT = JSON.stringify([
-  { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: 42 },
-]);
-
-const MISSING_OPTIONAL_FIELDS = JSON.stringify([
+const MINIMAL_ENTRY = JSON.stringify([
   { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '10' },
 ]);
 
-const EMPTY_ARRAY = JSON.stringify([]);
-
-const EMPTY_PAYMENTS_WRAPPER = JSON.stringify({ payments: [] });
-
 // ---------------------------------------------------------------------------
-// Tests — array format
+// Tests — valid inputs, top-level array format
 // ---------------------------------------------------------------------------
 
 describe('parseJSON — top-level array format', () => {
-  it('returns one record per array entry', () => {
-    const records = parseJSONString(ARRAY_FORMAT);
+  it('returns records and empty errors for a fully valid array', () => {
+    const { records, errors } = parseJSONString(ARRAY_FORMAT);
     expect(records).toHaveLength(2);
+    expect(errors).toHaveLength(0);
   });
 
   it('maps destination correctly', () => {
-    const [first] = parseJSONString(ARRAY_FORMAT);
-    expect(first.destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+    const { records } = parseJSONString(ARRAY_FORMAT);
+    expect(records[0].destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
   });
 
   it('maps string amount correctly', () => {
-    const [first] = parseJSONString(ARRAY_FORMAT);
-    expect(first.amount).toBe('150');
+    const { records } = parseJSONString(ARRAY_FORMAT);
+    expect(records[0].amount).toBe('150');
   });
 
   it('coerces numeric amount to string', () => {
-    const [, second] = parseJSONString(ARRAY_FORMAT);
-    expect(second.amount).toBe('75');
-    expect(typeof second.amount).toBe('string');
+    const { records } = parseJSONString(ARRAY_FORMAT);
+    expect(records[1].amount).toBe('75');
+    expect(typeof records[1].amount).toBe('string');
   });
 
   it('maps asset correctly', () => {
-    const [first] = parseJSONString(ARRAY_FORMAT);
-    expect(first.asset).toBe('USDC');
+    const { records } = parseJSONString(ARRAY_FORMAT);
+    expect(records[0].asset).toBe('USDC');
+  });
+
+  it('upper-cases the asset value', () => {
+    const { records } = parseJSONString(
+      JSON.stringify([{ destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '5', asset: 'usdc' }]),
+    );
+    expect(records[0].asset).toBe('USDC');
   });
 
   it('maps asset_issuer correctly', () => {
-    const [first] = parseJSONString(ARRAY_FORMAT);
-    expect(first.asset_issuer).toBe('GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN');
+    const { records } = parseJSONString(ARRAY_FORMAT);
+    expect(records[0].asset_issuer).toBe('GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN');
   });
 
   it('maps memo correctly', () => {
-    const [first] = parseJSONString(ARRAY_FORMAT);
-    expect(first.memo).toBe('Invoice-007');
+    const { records } = parseJSONString(ARRAY_FORMAT);
+    expect(records[0].memo).toBe('Invoice-007');
   });
 
   it('maps escrow_duration correctly', () => {
-    const [first] = parseJSONString(ARRAY_FORMAT);
-    expect(first.escrow_duration).toBe(3600);
+    const { records } = parseJSONString(ARRAY_FORMAT);
+    expect(records[0].escrow_duration).toBe(3600);
+  });
+
+  it('maps second entry independently', () => {
+    const { records } = parseJSONString(ARRAY_FORMAT);
+    expect(records[1].destination).toBe('GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGVA2XM9DWBF32LLVBF3');
+    expect(records[1].amount).toBe('75');
+    expect(records[1].asset).toBe('XLM');
+    expect(records[1].escrow_duration).toBe(0);
   });
 });
 
@@ -130,54 +139,260 @@ describe('parseJSON — top-level array format', () => {
 
 describe('parseJSON — object wrapper { payments: [...] } format', () => {
   it('reads entries from the payments key', () => {
-    const records = parseJSONString(OBJECT_WRAPPER_FORMAT);
+    const { records, errors } = parseJSONString(OBJECT_WRAPPER_FORMAT);
     expect(records).toHaveLength(1);
+    expect(errors).toHaveLength(0);
   });
 
   it('maps fields from wrapped format correctly', () => {
-    const [record] = parseJSONString(OBJECT_WRAPPER_FORMAT);
-    expect(record.destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
-    expect(record.amount).toBe('200');
-    expect(record.asset).toBe('EURC');
-    expect(record.memo).toBe('Payroll-Q1');
+    const { records } = parseJSONString(OBJECT_WRAPPER_FORMAT);
+    expect(records[0].destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+    expect(records[0].amount).toBe('200');
+    expect(records[0].asset).toBe('EURC');
+    expect(records[0].memo).toBe('Payroll-Q1');
+  });
+
+  it('throws when the payments key is not an array', () => {
+    expect(() =>
+      parseJSONString(JSON.stringify({ payments: 'not-an-array' })),
+    ).toThrow(/payments.*must be an array/i);
   });
 });
 
 // ---------------------------------------------------------------------------
-// Tests — default / fallback values
+// Tests — default / fallback values for missing optional fields
 // ---------------------------------------------------------------------------
 
 describe('parseJSON — default values for missing optional fields', () => {
-  it('defaults asset to XLM', () => {
-    const [record] = parseJSONString(MISSING_OPTIONAL_FIELDS);
-    expect(record.asset).toBe('XLM');
+  it('defaults asset to XLM when absent', () => {
+    const { records } = parseJSONString(MINIMAL_ENTRY);
+    expect(records[0].asset).toBe('XLM');
   });
 
-  it('defaults asset_issuer to empty string', () => {
-    const [record] = parseJSONString(MISSING_OPTIONAL_FIELDS);
-    expect(record.asset_issuer).toBe('');
+  it('defaults asset_issuer to empty string when absent', () => {
+    const { records } = parseJSONString(MINIMAL_ENTRY);
+    expect(records[0].asset_issuer).toBe('');
   });
 
-  it('defaults memo to empty string', () => {
-    const [record] = parseJSONString(MISSING_OPTIONAL_FIELDS);
-    expect(record.memo).toBe('');
+  it('defaults memo to empty string when absent', () => {
+    const { records } = parseJSONString(MINIMAL_ENTRY);
+    expect(records[0].memo).toBe('');
   });
 
-  it('defaults escrow_duration to 0', () => {
-    const [record] = parseJSONString(MISSING_OPTIONAL_FIELDS);
-    expect(record.escrow_duration).toBe(0);
+  it('defaults escrow_duration to 0 when absent', () => {
+    const { records } = parseJSONString(MINIMAL_ENTRY);
+    expect(records[0].escrow_duration).toBe(0);
   });
 });
 
 // ---------------------------------------------------------------------------
-// Tests — numeric amount coercion
+// Tests — field normalisation
 // ---------------------------------------------------------------------------
 
-describe('parseJSON — numeric amount coercion', () => {
+describe('parseJSON — field normalisation', () => {
+  it('trims whitespace from destination', () => {
+    const { records } = parseJSONString(
+      JSON.stringify([{ destination: '  GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2  ', amount: '5' }]),
+    );
+    expect(records[0].destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+  });
+
+  it('trims whitespace from amount', () => {
+    const { records } = parseJSONString(
+      JSON.stringify([{ destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '  42  ' }]),
+    );
+    expect(records[0].amount).toBe('42');
+  });
+
   it('converts numeric amount to string', () => {
-    const [record] = parseJSONString(NUMERIC_AMOUNT_FORMAT);
-    expect(record.amount).toBe('42');
-    expect(typeof record.amount).toBe('string');
+    const { records } = parseJSONString(
+      JSON.stringify([{ destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: 99 }]),
+    );
+    expect(records[0].amount).toBe('99');
+    expect(typeof records[0].amount).toBe('string');
+  });
+
+  it('upper-cases asset from lowercase input', () => {
+    const { records } = parseJSONString(
+      JSON.stringify([{ destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '5', asset: 'eurc' }]),
+    );
+    expect(records[0].asset).toBe('EURC');
+  });
+
+  it('upper-cases asset from mixed-case input', () => {
+    const { records } = parseJSONString(
+      JSON.stringify([{ destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '5', asset: 'Usdc' }]),
+    );
+    expect(records[0].asset).toBe('USDC');
+  });
+
+  it('trims whitespace from memo', () => {
+    const { records } = parseJSONString(
+      JSON.stringify([{ destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '5', memo: '  ref-001  ' }]),
+    );
+    expect(records[0].memo).toBe('ref-001');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — entry-level validation errors
+// ---------------------------------------------------------------------------
+
+describe('parseJSON — entry-level validation', () => {
+  it('returns an error when destination is missing', () => {
+    const { records, errors } = parseJSONString(
+      JSON.stringify([{ amount: '10' }]),
+    );
+    expect(records).toHaveLength(0);
+    expect(errors[0].index).toBe(1);
+    expect(errors[0].errors[0]).toMatch(/destination/i);
+  });
+
+  it('returns an error when destination is an empty string', () => {
+    const { errors } = parseJSONString(
+      JSON.stringify([{ destination: '', amount: '10' }]),
+    );
+    expect(errors[0].errors[0]).toMatch(/destination/i);
+  });
+
+  it('returns an error when amount is missing', () => {
+    const { errors } = parseJSONString(
+      JSON.stringify([{ destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2' }]),
+    );
+    expect(errors[0].errors[0]).toMatch(/amount/i);
+  });
+
+  it('returns an error when amount is not a number', () => {
+    const { errors } = parseJSONString(
+      JSON.stringify([{ destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: 'abc' }]),
+    );
+    expect(errors[0].errors[0]).toMatch(/not a valid number/i);
+  });
+
+  it('returns an error when amount is zero', () => {
+    const { errors } = parseJSONString(
+      JSON.stringify([{ destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: 0 }]),
+    );
+    expect(errors[0].errors[0]).toMatch(/greater than zero/i);
+  });
+
+  it('returns an error when amount is negative', () => {
+    const { errors } = parseJSONString(
+      JSON.stringify([{ destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: -5 }]),
+    );
+    expect(errors[0].errors[0]).toMatch(/greater than zero/i);
+  });
+
+  it('returns an error when asset is a non-string type', () => {
+    const { errors } = parseJSONString(
+      JSON.stringify([{ destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '5', asset: 123 }]),
+    );
+    expect(errors[0].errors[0]).toMatch(/asset.*must be a string/i);
+  });
+
+  it('returns an error when memo is a non-string type', () => {
+    const { errors } = parseJSONString(
+      JSON.stringify([{ destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '5', memo: 99 }]),
+    );
+    expect(errors[0].errors[0]).toMatch(/memo.*must be a string/i);
+  });
+
+  it('returns an error when escrow_duration is non-numeric', () => {
+    const { errors } = parseJSONString(
+      JSON.stringify([{ destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '5', escrow_duration: 'bad' }]),
+    );
+    expect(errors[0].errors[0]).toMatch(/escrow_duration.*not a valid number/i);
+  });
+
+  it('returns an error when escrow_duration is negative', () => {
+    const { errors } = parseJSONString(
+      JSON.stringify([{ destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '5', escrow_duration: -1 }]),
+    );
+    expect(errors[0].errors[0]).toMatch(/non-negative integer/i);
+  });
+
+  it('returns an error when escrow_duration is a non-integer', () => {
+    const { errors } = parseJSONString(
+      JSON.stringify([{ destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '5', escrow_duration: 1.5 }]),
+    );
+    expect(errors[0].errors[0]).toMatch(/non-negative integer/i);
+  });
+
+  it('returns an error when an entry is not an object', () => {
+    const { errors } = parseJSONString(JSON.stringify(['not-an-object']));
+    expect(errors[0].index).toBe(1);
+    expect(errors[0].errors[0]).toMatch(/expected a JSON object/i);
+  });
+
+  it('reports multiple errors for the same entry', () => {
+    const { errors } = parseJSONString(
+      JSON.stringify([{ destination: '', amount: 0 }]),
+    );
+    expect(errors[0].errors.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('assigns correct 1-based index to each error', () => {
+    const { errors } = parseJSONString(
+      JSON.stringify([
+        { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '10' }, // valid → index 1
+        { destination: '', amount: '5' },                                                          // invalid → index 2
+        { destination: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGVA2XM9DWBF32LLVBF3', amount: '20' }, // valid → index 3
+        { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: -1 },   // invalid → index 4
+      ]),
+    );
+    expect(errors).toHaveLength(2);
+    expect(errors[0].index).toBe(2);
+    expect(errors[1].index).toBe(4);
+  });
+
+  it('returns valid entries alongside entries that have errors', () => {
+    const { records, errors } = parseJSONString(
+      JSON.stringify([
+        { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '10' },
+        { destination: '', amount: '5' },
+        { destination: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGVA2XM9DWBF32LLVBF3', amount: '20' },
+      ]),
+    );
+    expect(records).toHaveLength(2);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('accepts escrow_duration of 0 (disabled escrow)', () => {
+    const { records, errors } = parseJSONString(
+      JSON.stringify([{ destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '10', escrow_duration: 0 }]),
+    );
+    expect(errors).toHaveLength(0);
+    expect(records[0].escrow_duration).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — top-level schema errors
+// ---------------------------------------------------------------------------
+
+describe('parseJSON — top-level schema errors', () => {
+  it('throws on malformed JSON', () => {
+    expect(() => parseJSONString('{ invalid json')).toThrow(SyntaxError);
+  });
+
+  it('throws when top-level value is a plain string', () => {
+    expect(() => parseJSONString('"just a string"')).toThrow(/expected a top-level array/i);
+  });
+
+  it('throws when top-level value is a number', () => {
+    expect(() => parseJSONString('42')).toThrow(/expected a top-level array/i);
+  });
+
+  it('throws when top-level object has no payments key', () => {
+    expect(() => parseJSONString(JSON.stringify({ data: [] }))).toThrow(/expected a top-level array/i);
+  });
+
+  it('throws when payments key is not an array', () => {
+    expect(() => parseJSONString(JSON.stringify({ payments: {} }))).toThrow(/must be an array/i);
+  });
+
+  it('throws when the file does not exist', () => {
+    expect(() => parseJSON('/nonexistent/path/file.json')).toThrow();
   });
 });
 
@@ -186,16 +401,20 @@ describe('parseJSON — numeric amount coercion', () => {
 // ---------------------------------------------------------------------------
 
 describe('parseJSON — edge cases', () => {
-  it('returns empty array for an empty top-level array', () => {
-    expect(parseJSONString(EMPTY_ARRAY)).toHaveLength(0);
+  it('returns empty records and errors for an empty top-level array', () => {
+    const { records, errors } = parseJSONString('[]');
+    expect(records).toHaveLength(0);
+    expect(errors).toHaveLength(0);
   });
 
-  it('returns empty array for an empty payments wrapper', () => {
-    expect(parseJSONString(EMPTY_PAYMENTS_WRAPPER)).toHaveLength(0);
+  it('returns empty records and errors for an empty payments wrapper', () => {
+    const { records, errors } = parseJSONString(JSON.stringify({ payments: [] }));
+    expect(records).toHaveLength(0);
+    expect(errors).toHaveLength(0);
   });
 
-  it('returns all required PaymentRecord keys on every record', () => {
-    const records = parseJSONString(ARRAY_FORMAT);
+  it('returns all required PaymentRecord keys on every valid record', () => {
+    const { records } = parseJSONString(ARRAY_FORMAT);
     for (const record of records) {
       expect(record).toHaveProperty('destination');
       expect(record).toHaveProperty('amount');
@@ -204,13 +423,5 @@ describe('parseJSON — edge cases', () => {
       expect(record).toHaveProperty('memo');
       expect(record).toHaveProperty('escrow_duration');
     }
-  });
-
-  it('throws on malformed JSON', () => {
-    expect(() => parseJSONString('{ invalid json')).toThrow();
-  });
-
-  it('throws when the file does not exist', () => {
-    expect(() => parseJSON('/nonexistent/path/file.json')).toThrow();
   });
 });

--- a/cli/src/parsers/json-parser.ts
+++ b/cli/src/parsers/json-parser.ts
@@ -1,27 +1,244 @@
 import * as fs from 'fs';
 import { PaymentRecord } from '../types';
 
-interface JSONPaymentInput {
-  destination?: string;
-  amount?: string | number;
-  asset?: string;
-  asset_issuer?: string;
-  memo?: string;
-  escrow_duration?: number;
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** A single entry that failed validation — carries its 1-based index and errors. */
+export interface JSONEntryError {
+  /**
+   * 1-based position in the payments array (entry 1 = first payment object).
+   */
+  index: number;
+  errors: string[];
 }
 
-export function parseJSON(filePath: string): PaymentRecord[] {
+/** Result returned by parseJSON. */
+export interface JSONParseResult {
+  /** Entries that passed all validation checks, ready for batch submission. */
+  records: PaymentRecord[];
+  /** Entries that failed validation, each with their index and error messages. */
+  errors: JSONEntryError[];
+}
+
+// ---------------------------------------------------------------------------
+// Accepted raw shape of a single payment entry in the JSON input
+// ---------------------------------------------------------------------------
+
+interface RawPaymentEntry {
+  destination?: unknown;
+  amount?: unknown;
+  asset?: unknown;
+  asset_issuer?: unknown;
+  memo?: unknown;
+  escrow_duration?: unknown;
+  // Allow unknown extra keys without TypeScript errors
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a JSON payment file into a validated set of PaymentRecords.
+ *
+ * ### Accepted top-level shapes
+ * - Array of payment objects: `[{ destination, amount, ... }, ...]`
+ * - Wrapper object with a `payments` key: `{ "payments": [...] }`
+ *
+ * ### Validation
+ * Every entry is validated before being included in `records`.  Entries that
+ * fail validation are collected in `errors` with their 1-based index and a
+ * list of human-readable error messages.
+ *
+ * ### Required fields
+ * `destination` and `amount` are required and must be non-empty.
+ *
+ * ### Field normalisation
+ * - `amount`: accepted as a string or number; normalised to a trimmed string.
+ * - `asset`: trimmed and upper-cased; defaults to `"XLM"` when absent.
+ * - `asset_issuer`, `memo`: trimmed strings, default to `""`.
+ * - `escrow_duration`: must be a non-negative integer; defaults to `0` when absent.
+ *
+ * @param filePath  Absolute or relative path to the JSON file.
+ * @returns         `{ records, errors }` — valid records and per-entry errors.
+ * @throws          If the file cannot be read, the content is not valid JSON,
+ *                  or the top-level value is not an array or a `{ payments }` object.
+ */
+export function parseJSON(filePath: string): JSONParseResult {
   const content = fs.readFileSync(filePath, 'utf-8');
-  const data = JSON.parse(content);
 
-  const payments: JSONPaymentInput[] = Array.isArray(data) ? data : data.payments || [];
+  let data: unknown;
+  try {
+    data = JSON.parse(content);
+  } catch (err) {
+    throw new SyntaxError(
+      `Invalid JSON in file "${filePath}": ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 
-  return payments.map((entry) => ({
-    destination: entry.destination || '',
-    amount: String(entry.amount || '0'),
-    asset: entry.asset || 'XLM',
-    asset_issuer: entry.asset_issuer || '',
-    memo: entry.memo || '',
-    escrow_duration: entry.escrow_duration || 0,
-  }));
+  const rawEntries = extractEntries(data, filePath);
+
+  const records: PaymentRecord[] = [];
+  const errors: JSONEntryError[] = [];
+
+  for (let i = 0; i < rawEntries.length; i++) {
+    const index = i + 1; // 1-based
+    const entry = rawEntries[i];
+
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      errors.push({
+        index,
+        errors: [`Entry ${index}: expected a JSON object, got ${Array.isArray(entry) ? 'array' : String(entry)}`],
+      });
+      continue;
+    }
+
+    const raw = entry as RawPaymentEntry;
+    const entryErrors = validateEntry(raw, index);
+
+    if (entryErrors.length > 0) {
+      errors.push({ index, errors: entryErrors });
+      continue;
+    }
+
+    records.push(buildRecord(raw));
+  }
+
+  return { records, errors };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the flat array of raw payment entries from the parsed JSON value.
+ * Accepts both a top-level array and a `{ payments: [...] }` wrapper.
+ * Throws with a clear message for any other shape.
+ */
+function extractEntries(data: unknown, filePath: string): unknown[] {
+  if (Array.isArray(data)) {
+    return data;
+  }
+
+  if (data !== null && typeof data === 'object' && !Array.isArray(data)) {
+    const obj = data as Record<string, unknown>;
+    if ('payments' in obj) {
+      if (!Array.isArray(obj.payments)) {
+        throw new TypeError(
+          `Invalid JSON in file "${filePath}": "payments" key must be an array, ` +
+            `got ${typeof obj.payments}`,
+        );
+      }
+      return obj.payments as unknown[];
+    }
+  }
+
+  throw new TypeError(
+    `Invalid JSON in file "${filePath}": expected a top-level array or an object ` +
+      `with a "payments" key, got ${Array.isArray(data) ? 'array' : typeof data}`,
+  );
+}
+
+/**
+ * Validate a single raw payment entry object.
+ * Returns an array of human-readable error strings; empty means valid.
+ */
+function validateEntry(entry: RawPaymentEntry, index: number): string[] {
+  const errs: string[] = [];
+
+  // --- destination (required, non-empty string) ---
+  const destination = trimStr(entry.destination);
+  if (destination === undefined) {
+    errs.push(`Entry ${index}: missing required field "destination"`);
+  } else if (destination.length === 0) {
+    errs.push(`Entry ${index}: "destination" must not be empty`);
+  } else if (typeof entry.destination !== 'string') {
+    errs.push(`Entry ${index}: "destination" must be a string, got ${typeof entry.destination}`);
+  }
+
+  // --- amount (required, positive number) ---
+  const rawAmount = entry.amount;
+  if (rawAmount === undefined || rawAmount === null || rawAmount === '') {
+    errs.push(`Entry ${index}: missing required field "amount"`);
+  } else {
+    const amountStr = trimStr(rawAmount);
+    const num = Number(amountStr);
+    if (amountStr === undefined || isNaN(num)) {
+      errs.push(`Entry ${index}: "amount" is not a valid number (got ${JSON.stringify(rawAmount)})`);
+    } else if (num <= 0) {
+      errs.push(`Entry ${index}: "amount" must be greater than zero (got ${num})`);
+    }
+  }
+
+  // --- asset (optional, must be a non-empty string if present) ---
+  if (entry.asset !== undefined && entry.asset !== null && entry.asset !== '') {
+    if (typeof entry.asset !== 'string') {
+      errs.push(`Entry ${index}: "asset" must be a string, got ${typeof entry.asset}`);
+    } else if (entry.asset.trim().length === 0) {
+      errs.push(`Entry ${index}: "asset" must not be blank`);
+    }
+  }
+
+  // --- asset_issuer (optional, must be a string if present) ---
+  if (entry.asset_issuer !== undefined && entry.asset_issuer !== null && entry.asset_issuer !== '') {
+    if (typeof entry.asset_issuer !== 'string') {
+      errs.push(`Entry ${index}: "asset_issuer" must be a string, got ${typeof entry.asset_issuer}`);
+    }
+  }
+
+  // --- memo (optional, must be a string if present) ---
+  if (entry.memo !== undefined && entry.memo !== null && entry.memo !== '') {
+    if (typeof entry.memo !== 'string') {
+      errs.push(`Entry ${index}: "memo" must be a string, got ${typeof entry.memo}`);
+    }
+  }
+
+  // --- escrow_duration (optional, must be a non-negative integer if present) ---
+  if (entry.escrow_duration !== undefined && entry.escrow_duration !== null) {
+    const n = Number(entry.escrow_duration);
+    if (isNaN(n)) {
+      errs.push(
+        `Entry ${index}: "escrow_duration" is not a valid number ` +
+          `(got ${JSON.stringify(entry.escrow_duration)}) — use 0 to disable escrow`,
+      );
+    } else if (!Number.isInteger(n) || n < 0) {
+      errs.push(
+        `Entry ${index}: "escrow_duration" must be a non-negative integer (got ${n})`,
+      );
+    }
+  }
+
+  return errs;
+}
+
+/** Build a normalised PaymentRecord from a validated entry. */
+function buildRecord(entry: RawPaymentEntry): PaymentRecord {
+  const assetRaw = trimStr(entry.asset);
+  const asset = assetRaw ? assetRaw.toUpperCase() : 'XLM';
+
+  return {
+    destination: (trimStr(entry.destination) ?? '').trim(),
+    amount: String(trimStr(entry.amount) ?? '0').trim(),
+    asset,
+    asset_issuer: trimStr(entry.asset_issuer) ?? '',
+    memo: trimStr(entry.memo) ?? '',
+    escrow_duration: parseEscrowDuration(entry.escrow_duration),
+  };
+}
+
+/** Safely coerce a value to a trimmed string; returns undefined for null/undefined/empty. */
+function trimStr(value: unknown): string | undefined {
+  if (value === null || value === undefined || value === '') return undefined;
+  const s = String(value).trim();
+  return s.length > 0 ? s : undefined;
+}
+
+function parseEscrowDuration(value: unknown): number {
+  if (value === undefined || value === null) return 0;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0;
 }

--- a/cli/src/parsers/xlsx-parser.test.ts
+++ b/cli/src/parsers/xlsx-parser.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for the XLSX parser.
+ *
+ * Uses the `xlsx` library to programmatically build workbooks in memory and
+ * write them to temp files, so no fixture files are needed on disk.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as XLSX from 'xlsx';
+import { parseXLSX } from './xlsx-parser';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type SheetRow = Record<string, string | number | undefined>;
+
+/** Build a single-sheet .xlsx temp file from an array of row objects. */
+function writeTempXLSX(rows: SheetRow[]): string {
+  const tmpFile = path.join(
+    os.tmpdir(),
+    `xlsx-test-${Date.now()}-${Math.random().toString(36).slice(2)}.xlsx`,
+  );
+  const ws = XLSX.utils.json_to_sheet(rows);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
+  XLSX.writeFile(wb, tmpFile);
+  return tmpFile;
+}
+
+function parseRows(rows: SheetRow[]) {
+  const file = writeTempXLSX(rows);
+  try {
+    return parseXLSX(file);
+  } finally {
+    fs.unlinkSync(file);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sample row data
+// ---------------------------------------------------------------------------
+
+const FULL_ROWS: SheetRow[] = [
+  {
+    destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2',
+    amount: '100',
+    asset: 'USDC',
+    asset_issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+    memo: 'Invoice-001',
+    escrow_duration: 3600,
+  },
+  {
+    destination: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGVA2XM9DWBF32LLVBF3',
+    amount: 50,
+    asset: 'XLM',
+    asset_issuer: '',
+    memo: '',
+    escrow_duration: 0,
+  },
+];
+
+const MINIMAL_ROWS: SheetRow[] = [
+  { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '200' },
+];
+
+const NUMERIC_AMOUNT_ROW: SheetRow[] = [
+  { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: 77 },
+];
+
+const INVALID_ESCROW_ROW: SheetRow[] = [
+  {
+    destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2',
+    amount: '10',
+    escrow_duration: 'bad',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tests — valid inputs
+// ---------------------------------------------------------------------------
+
+describe('parseXLSX — valid inputs', () => {
+  it('returns one record per data row', () => {
+    expect(parseRows(FULL_ROWS)).toHaveLength(2);
+  });
+
+  it('maps destination correctly', () => {
+    const [first] = parseRows(FULL_ROWS);
+    expect(first.destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+  });
+
+  it('maps string amount correctly', () => {
+    const [first] = parseRows(FULL_ROWS);
+    expect(first.amount).toBe('100');
+  });
+
+  it('coerces numeric amount to string', () => {
+    const [, second] = parseRows(FULL_ROWS);
+    expect(second.amount).toBe('50');
+    expect(typeof second.amount).toBe('string');
+  });
+
+  it('maps asset correctly', () => {
+    const [first] = parseRows(FULL_ROWS);
+    expect(first.asset).toBe('USDC');
+  });
+
+  it('maps asset_issuer correctly', () => {
+    const [first] = parseRows(FULL_ROWS);
+    expect(first.asset_issuer).toBe('GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN');
+  });
+
+  it('maps memo correctly', () => {
+    const [first] = parseRows(FULL_ROWS);
+    expect(first.memo).toBe('Invoice-001');
+  });
+
+  it('maps escrow_duration as a number', () => {
+    const [first] = parseRows(FULL_ROWS);
+    expect(first.escrow_duration).toBe(3600);
+  });
+
+  it('maps second row independently', () => {
+    const [, second] = parseRows(FULL_ROWS);
+    expect(second.destination).toBe('GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGVA2XM9DWBF32LLVBF3');
+    expect(second.amount).toBe('50');
+    expect(second.asset).toBe('XLM');
+    expect(second.escrow_duration).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — default / fallback values
+// ---------------------------------------------------------------------------
+
+describe('parseXLSX — default values for missing optional columns', () => {
+  it('defaults asset to XLM', () => {
+    const [record] = parseRows(MINIMAL_ROWS);
+    expect(record.asset).toBe('XLM');
+  });
+
+  it('defaults asset_issuer to empty string', () => {
+    const [record] = parseRows(MINIMAL_ROWS);
+    expect(record.asset_issuer).toBe('');
+  });
+
+  it('defaults memo to empty string', () => {
+    const [record] = parseRows(MINIMAL_ROWS);
+    expect(record.memo).toBe('');
+  });
+
+  it('defaults escrow_duration to 0', () => {
+    const [record] = parseRows(MINIMAL_ROWS);
+    expect(record.escrow_duration).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — edge cases
+// ---------------------------------------------------------------------------
+
+describe('parseXLSX — edge cases', () => {
+  it('returns empty array for a sheet with no data rows', () => {
+    const records = parseRows([]);
+    expect(records).toHaveLength(0);
+  });
+
+  it('coerces numeric cell amount to string', () => {
+    const [record] = parseRows(NUMERIC_AMOUNT_ROW);
+    expect(record.amount).toBe('77');
+    expect(typeof record.amount).toBe('string');
+  });
+
+  it('treats non-numeric escrow_duration as 0', () => {
+    const [record] = parseRows(INVALID_ESCROW_ROW);
+    expect(record.escrow_duration).toBe(0);
+  });
+
+  it('uses only the first sheet when the workbook has multiple sheets', () => {
+    const tmpFile = path.join(
+      os.tmpdir(),
+      `xlsx-multi-${Date.now()}.xlsx`,
+    );
+    const ws1 = XLSX.utils.json_to_sheet([
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '10' },
+    ]);
+    const ws2 = XLSX.utils.json_to_sheet([
+      { destination: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGVA2XM9DWBF32LLVBF3', amount: '20' },
+      { destination: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGVA2XM9DWBF32LLVBF3', amount: '30' },
+    ]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws1, 'Payments');
+    XLSX.utils.book_append_sheet(wb, ws2, 'Other');
+    XLSX.writeFile(wb, tmpFile);
+    try {
+      const records = parseXLSX(tmpFile);
+      expect(records).toHaveLength(1);
+      expect(records[0].amount).toBe('10');
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it('returns all required PaymentRecord keys on every record', () => {
+    const records = parseRows(FULL_ROWS);
+    for (const record of records) {
+      expect(record).toHaveProperty('destination');
+      expect(record).toHaveProperty('amount');
+      expect(record).toHaveProperty('asset');
+      expect(record).toHaveProperty('asset_issuer');
+      expect(record).toHaveProperty('memo');
+      expect(record).toHaveProperty('escrow_duration');
+    }
+  });
+
+  it('throws when the file does not exist', () => {
+    expect(() => parseXLSX('/nonexistent/path/file.xlsx')).toThrow();
+  });
+});

--- a/cli/src/parsers/xlsx-parser.test.ts
+++ b/cli/src/parsers/xlsx-parser.test.ts
@@ -40,7 +40,7 @@ function parseRows(rows: SheetRow[]) {
 }
 
 // ---------------------------------------------------------------------------
-// Sample row data
+// Sample row data — canonical headers
 // ---------------------------------------------------------------------------
 
 const FULL_ROWS: SheetRow[] = [
@@ -70,91 +70,349 @@ const NUMERIC_AMOUNT_ROW: SheetRow[] = [
   { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: 77 },
 ];
 
-const INVALID_ESCROW_ROW: SheetRow[] = [
-  {
-    destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2',
-    amount: '10',
-    escrow_duration: 'bad',
-  },
-];
-
 // ---------------------------------------------------------------------------
-// Tests — valid inputs
+// Tests — valid inputs (canonical headers)
 // ---------------------------------------------------------------------------
 
 describe('parseXLSX — valid inputs', () => {
-  it('returns one record per data row', () => {
-    expect(parseRows(FULL_ROWS)).toHaveLength(2);
+  it('returns one record per valid data row', () => {
+    const { records, errors } = parseRows(FULL_ROWS);
+    expect(records).toHaveLength(2);
+    expect(errors).toHaveLength(0);
   });
 
   it('maps destination correctly', () => {
-    const [first] = parseRows(FULL_ROWS);
-    expect(first.destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+    const { records } = parseRows(FULL_ROWS);
+    expect(records[0].destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
   });
 
   it('maps string amount correctly', () => {
-    const [first] = parseRows(FULL_ROWS);
-    expect(first.amount).toBe('100');
+    const { records } = parseRows(FULL_ROWS);
+    expect(records[0].amount).toBe('100');
   });
 
   it('coerces numeric amount to string', () => {
-    const [, second] = parseRows(FULL_ROWS);
-    expect(second.amount).toBe('50');
-    expect(typeof second.amount).toBe('string');
+    const { records } = parseRows(FULL_ROWS);
+    expect(records[1].amount).toBe('50');
+    expect(typeof records[1].amount).toBe('string');
   });
 
   it('maps asset correctly', () => {
-    const [first] = parseRows(FULL_ROWS);
-    expect(first.asset).toBe('USDC');
+    const { records } = parseRows(FULL_ROWS);
+    expect(records[0].asset).toBe('USDC');
   });
 
   it('maps asset_issuer correctly', () => {
-    const [first] = parseRows(FULL_ROWS);
-    expect(first.asset_issuer).toBe('GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN');
+    const { records } = parseRows(FULL_ROWS);
+    expect(records[0].asset_issuer).toBe('GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN');
   });
 
   it('maps memo correctly', () => {
-    const [first] = parseRows(FULL_ROWS);
-    expect(first.memo).toBe('Invoice-001');
+    const { records } = parseRows(FULL_ROWS);
+    expect(records[0].memo).toBe('Invoice-001');
   });
 
   it('maps escrow_duration as a number', () => {
-    const [first] = parseRows(FULL_ROWS);
-    expect(first.escrow_duration).toBe(3600);
+    const { records } = parseRows(FULL_ROWS);
+    expect(records[0].escrow_duration).toBe(3600);
   });
 
   it('maps second row independently', () => {
-    const [, second] = parseRows(FULL_ROWS);
-    expect(second.destination).toBe('GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGVA2XM9DWBF32LLVBF3');
-    expect(second.amount).toBe('50');
-    expect(second.asset).toBe('XLM');
-    expect(second.escrow_duration).toBe(0);
+    const { records } = parseRows(FULL_ROWS);
+    expect(records[1].destination).toBe('GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGVA2XM9DWBF32LLVBF3');
+    expect(records[1].amount).toBe('50');
+    expect(records[1].asset).toBe('XLM');
+    expect(records[1].escrow_duration).toBe(0);
+  });
+
+  it('coerces numeric cell amount to string', () => {
+    const { records } = parseRows(NUMERIC_AMOUNT_ROW);
+    expect(records[0].amount).toBe('77');
+    expect(typeof records[0].amount).toBe('string');
   });
 });
 
 // ---------------------------------------------------------------------------
-// Tests — default / fallback values
+// Tests — default / fallback values for missing optional columns
 // ---------------------------------------------------------------------------
 
 describe('parseXLSX — default values for missing optional columns', () => {
   it('defaults asset to XLM', () => {
-    const [record] = parseRows(MINIMAL_ROWS);
-    expect(record.asset).toBe('XLM');
+    const { records } = parseRows(MINIMAL_ROWS);
+    expect(records[0].asset).toBe('XLM');
   });
 
   it('defaults asset_issuer to empty string', () => {
-    const [record] = parseRows(MINIMAL_ROWS);
-    expect(record.asset_issuer).toBe('');
+    const { records } = parseRows(MINIMAL_ROWS);
+    expect(records[0].asset_issuer).toBe('');
   });
 
   it('defaults memo to empty string', () => {
-    const [record] = parseRows(MINIMAL_ROWS);
-    expect(record.memo).toBe('');
+    const { records } = parseRows(MINIMAL_ROWS);
+    expect(records[0].memo).toBe('');
   });
 
   it('defaults escrow_duration to 0', () => {
-    const [record] = parseRows(MINIMAL_ROWS);
-    expect(record.escrow_duration).toBe(0);
+    const { records } = parseRows(MINIMAL_ROWS);
+    expect(records[0].escrow_duration).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — header normalisation
+// ---------------------------------------------------------------------------
+
+describe('parseXLSX — header normalisation', () => {
+  it('accepts uppercase headers (DESTINATION, AMOUNT)', () => {
+    const { records, errors } = parseRows([
+      { DESTINATION: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', AMOUNT: '10' },
+    ] as SheetRow[]);
+    expect(errors).toHaveLength(0);
+    expect(records[0].destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+    expect(records[0].amount).toBe('10');
+  });
+
+  it('accepts mixed-case headers (Destination, Amount)', () => {
+    const { records, errors } = parseRows([
+      { Destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', Amount: '25' },
+    ] as SheetRow[]);
+    expect(errors).toHaveLength(0);
+    expect(records[0].destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+    expect(records[0].amount).toBe('25');
+  });
+
+  it('accepts "amt" as an alias for amount', () => {
+    const { records } = parseRows([
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amt: '30' },
+    ] as SheetRow[]);
+    expect(records[0].amount).toBe('30');
+  });
+
+  it('accepts "recipient" as an alias for destination', () => {
+    const { records } = parseRows([
+      { recipient: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '5' },
+    ] as SheetRow[]);
+    expect(records[0].destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+  });
+
+  it('accepts "currency" as an alias for asset', () => {
+    const { records } = parseRows([
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '5', currency: 'EURC' },
+    ] as SheetRow[]);
+    expect(records[0].asset).toBe('EURC');
+  });
+
+  it('accepts "token" as an alias for asset', () => {
+    const { records } = parseRows([
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '5', token: 'USDC' },
+    ] as SheetRow[]);
+    expect(records[0].asset).toBe('USDC');
+  });
+
+  it('accepts "reference" as an alias for memo', () => {
+    const { records } = parseRows([
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '5', reference: 'REF-001' },
+    ] as SheetRow[]);
+    expect(records[0].memo).toBe('REF-001');
+  });
+
+  it('accepts "escrow duration" (with space) as an alias for escrow_duration', () => {
+    const { records } = parseRows([
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '5', 'escrow duration': 7200 },
+    ] as SheetRow[]);
+    expect(records[0].escrow_duration).toBe(7200);
+  });
+
+  it('accepts "issuer" as an alias for asset_issuer', () => {
+    const { records } = parseRows([
+      {
+        destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2',
+        amount: '5',
+        issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+      },
+    ] as SheetRow[]);
+    expect(records[0].asset_issuer).toBe('GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN');
+  });
+
+  it('trims whitespace from header names before normalising', () => {
+    // Simulate a spreadsheet with accidentally padded column headers
+    const ws = XLSX.utils.aoa_to_sheet([
+      ['  destination  ', '  amount  '],
+      ['GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', '15'],
+    ]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
+    const tmpFile = path.join(os.tmpdir(), `xlsx-trim-${Date.now()}.xlsx`);
+    XLSX.writeFile(wb, tmpFile);
+    try {
+      const { records, errors } = parseXLSX(tmpFile);
+      expect(errors).toHaveLength(0);
+      expect(records[0].destination).toBe('GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2');
+      expect(records[0].amount).toBe('15');
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — required column validation
+// ---------------------------------------------------------------------------
+
+describe('parseXLSX — required column validation', () => {
+  it('throws when both destination and amount columns are absent', () => {
+    const ws = XLSX.utils.aoa_to_sheet([['note'], ['hello']]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
+    const tmpFile = path.join(os.tmpdir(), `xlsx-nocols-${Date.now()}.xlsx`);
+    XLSX.writeFile(wb, tmpFile);
+    try {
+      expect(() => parseXLSX(tmpFile)).toThrow(/missing required column/i);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it('throws when only the destination column is missing', () => {
+    const ws = XLSX.utils.aoa_to_sheet([['amount'], ['100']]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
+    const tmpFile = path.join(os.tmpdir(), `xlsx-nodest-${Date.now()}.xlsx`);
+    XLSX.writeFile(wb, tmpFile);
+    try {
+      expect(() => parseXLSX(tmpFile)).toThrow(/destination/i);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it('throws when only the amount column is missing', () => {
+    const ws = XLSX.utils.aoa_to_sheet([['destination'], ['GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2']]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
+    const tmpFile = path.join(os.tmpdir(), `xlsx-noamt-${Date.now()}.xlsx`);
+    XLSX.writeFile(wb, tmpFile);
+    try {
+      expect(() => parseXLSX(tmpFile)).toThrow(/amount/i);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it('error message includes the found headers', () => {
+    const ws = XLSX.utils.aoa_to_sheet([['note', 'ref'], ['x', 'y']]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
+    const tmpFile = path.join(os.tmpdir(), `xlsx-hdrs-${Date.now()}.xlsx`);
+    XLSX.writeFile(wb, tmpFile);
+    try {
+      expect(() => parseXLSX(tmpFile)).toThrow(/found headers/i);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — row-level validation
+// ---------------------------------------------------------------------------
+
+describe('parseXLSX — row-level validation', () => {
+  it('returns a row error when destination is empty', () => {
+    const { records, errors } = parseRows([
+      { destination: '', amount: '10' },
+    ]);
+    expect(records).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].row).toBe(2);
+    expect(errors[0].errors[0]).toMatch(/destination/i);
+  });
+
+  it('returns a row error when amount is empty', () => {
+    const { records, errors } = parseRows([
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '' },
+    ]);
+    expect(records).toHaveLength(0);
+    expect(errors[0].row).toBe(2);
+    expect(errors[0].errors[0]).toMatch(/amount/i);
+  });
+
+  it('returns a row error when amount is not a number', () => {
+    const { errors } = parseRows([
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: 'abc' },
+    ]);
+    expect(errors[0].errors[0]).toMatch(/not a valid number/i);
+  });
+
+  it('returns a row error when amount is zero', () => {
+    const { errors } = parseRows([
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '0' },
+    ]);
+    expect(errors[0].errors[0]).toMatch(/greater than zero/i);
+  });
+
+  it('returns a row error when amount is negative', () => {
+    const { errors } = parseRows([
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '-5' },
+    ]);
+    expect(errors[0].errors[0]).toMatch(/greater than zero/i);
+  });
+
+  it('returns a row error when escrow_duration is non-numeric', () => {
+    const { errors } = parseRows([
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '10', escrow_duration: 'bad' },
+    ]);
+    expect(errors[0].errors[0]).toMatch(/escrow_duration/i);
+  });
+
+  it('returns a row error when escrow_duration is negative', () => {
+    const { errors } = parseRows([
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '10', escrow_duration: -1 },
+    ]);
+    expect(errors[0].errors[0]).toMatch(/non-negative/i);
+  });
+
+  it('reports multiple errors per row when both required fields are invalid', () => {
+    const { errors } = parseRows([{ destination: '', amount: '0' }]);
+    expect(errors[0].errors.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('assigns correct 1-based row numbers (first data row = 2)', () => {
+    const { errors } = parseRows([
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '10' }, // row 2 — valid
+      { destination: '', amount: '10' },  // row 3 — invalid
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '20' }, // row 4 — valid
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '-1' }, // row 5 — invalid
+    ]);
+    expect(errors).toHaveLength(2);
+    expect(errors[0].row).toBe(3);
+    expect(errors[1].row).toBe(5);
+  });
+
+  it('valid rows are returned even when some rows have errors', () => {
+    const { records, errors } = parseRows([
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '10' },
+      { destination: '', amount: '10' },
+      { destination: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGVA2XM9DWBF32LLVBF3', amount: '20' },
+    ]);
+    expect(records).toHaveLength(2);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('accepts escrow_duration of 0 (disabled escrow)', () => {
+    const { records, errors } = parseRows([
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '10', escrow_duration: 0 },
+    ]);
+    expect(errors).toHaveLength(0);
+    expect(records[0].escrow_duration).toBe(0);
+  });
+
+  it('rejects a fractional escrow_duration — must be a non-negative integer', () => {
+    const { errors } = parseRows([
+      { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '10', escrow_duration: 3600.9 },
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].errors[0]).toMatch(/non-negative integer/i);
   });
 });
 
@@ -163,27 +421,14 @@ describe('parseXLSX — default values for missing optional columns', () => {
 // ---------------------------------------------------------------------------
 
 describe('parseXLSX — edge cases', () => {
-  it('returns empty array for a sheet with no data rows', () => {
-    const records = parseRows([]);
+  it('returns empty records and errors for a sheet with no data rows', () => {
+    const { records, errors } = parseRows([]);
     expect(records).toHaveLength(0);
-  });
-
-  it('coerces numeric cell amount to string', () => {
-    const [record] = parseRows(NUMERIC_AMOUNT_ROW);
-    expect(record.amount).toBe('77');
-    expect(typeof record.amount).toBe('string');
-  });
-
-  it('treats non-numeric escrow_duration as 0', () => {
-    const [record] = parseRows(INVALID_ESCROW_ROW);
-    expect(record.escrow_duration).toBe(0);
+    expect(errors).toHaveLength(0);
   });
 
   it('uses only the first sheet when the workbook has multiple sheets', () => {
-    const tmpFile = path.join(
-      os.tmpdir(),
-      `xlsx-multi-${Date.now()}.xlsx`,
-    );
+    const tmpFile = path.join(os.tmpdir(), `xlsx-multi-${Date.now()}.xlsx`);
     const ws1 = XLSX.utils.json_to_sheet([
       { destination: 'GBDEVU63Y6BHHYWUMAS6NHXVWUIQEJBACC7F6QXJZUCM4TBNEOUFL2', amount: '10' },
     ]);
@@ -196,7 +441,7 @@ describe('parseXLSX — edge cases', () => {
     XLSX.utils.book_append_sheet(wb, ws2, 'Other');
     XLSX.writeFile(wb, tmpFile);
     try {
-      const records = parseXLSX(tmpFile);
+      const { records } = parseXLSX(tmpFile);
       expect(records).toHaveLength(1);
       expect(records[0].amount).toBe('10');
     } finally {
@@ -204,8 +449,8 @@ describe('parseXLSX — edge cases', () => {
     }
   });
 
-  it('returns all required PaymentRecord keys on every record', () => {
-    const records = parseRows(FULL_ROWS);
+  it('returns all required PaymentRecord keys on every valid record', () => {
+    const { records } = parseRows(FULL_ROWS);
     for (const record of records) {
       expect(record).toHaveProperty('destination');
       expect(record).toHaveProperty('amount');

--- a/cli/src/parsers/xlsx-parser.ts
+++ b/cli/src/parsers/xlsx-parser.ts
@@ -1,27 +1,276 @@
 import * as XLSX from 'xlsx';
 import { PaymentRecord } from '../types';
 
-interface XLSXRow {
-  destination?: string;
-  amount?: string | number;
-  asset?: string;
-  asset_issuer?: string;
-  memo?: string;
-  escrow_duration?: string | number;
+// ---------------------------------------------------------------------------
+// Column header normalisation
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps every accepted spelling/casing variant for a column to its canonical
+ * internal key.  The normalisation step converts each raw header to lowercase
+ * and strips leading/trailing whitespace before looking it up here, so the
+ * mapping only needs lowercase keys.
+ *
+ * Canonical keys match the PaymentRecord field names so the rest of the parser
+ * can use them directly.
+ */
+const HEADER_ALIASES: Record<string, string> = {
+  // destination
+  destination: 'destination',
+  dest: 'destination',
+  recipient: 'destination',
+  'recipient address': 'destination',
+  'wallet address': 'destination',
+  address: 'destination',
+  'stellar address': 'destination',
+  // amount
+  amount: 'amount',
+  amt: 'amount',
+  value: 'amount',
+  'payment amount': 'amount',
+  // asset
+  asset: 'asset',
+  currency: 'asset',
+  token: 'asset',
+  'asset code': 'asset',
+  coin: 'asset',
+  // asset_issuer
+  asset_issuer: 'asset_issuer',
+  'asset issuer': 'asset_issuer',
+  issuer: 'asset_issuer',
+  'issuer address': 'asset_issuer',
+  // memo
+  memo: 'memo',
+  note: 'memo',
+  notes: 'memo',
+  reference: 'memo',
+  description: 'memo',
+  ref: 'memo',
+  // escrow_duration
+  escrow_duration: 'escrow_duration',
+  'escrow duration': 'escrow_duration',
+  escrow: 'escrow_duration',
+  'lock duration': 'escrow_duration',
+  'lock time': 'escrow_duration',
+  duration: 'escrow_duration',
+};
+
+/** Columns that must be present and non-empty for a row to be valid. */
+const REQUIRED_COLUMNS = ['destination', 'amount'] as const;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** A row that failed validation — carries the 1-based row number and all errors. */
+export interface XLSXRowError {
+  /** 1-based row number in the spreadsheet (header = row 1, first data row = 2). */
+  row: number;
+  errors: string[];
 }
 
-export function parseXLSX(filePath: string): PaymentRecord[] {
+/** Result returned by parseXLSX. */
+export interface XLSXParseResult {
+  /** Rows that passed validation and are ready for batch submission. */
+  records: PaymentRecord[];
+  /** Rows that failed validation, each with their row number and error list. */
+  errors: XLSXRowError[];
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse an XLSX / XLS file into a validated set of PaymentRecords.
+ *
+ * ### Header normalisation
+ * Column headers are matched case-insensitively and trimmed.  Common aliases
+ * (e.g. "Amount", "AMOUNT", "amt", "Payment Amount") are all accepted and
+ * mapped to the canonical field name.
+ *
+ * ### Validation
+ * Every data row is validated before being included in `records`.  Rows that
+ * fail validation are collected in `errors` with their 1-based row number and
+ * a list of human-readable error messages.  The caller can log or surface
+ * these errors before submitting the batch.
+ *
+ * ### Required columns
+ * `destination` and `amount` must be present in the sheet headers, otherwise
+ * the function throws with a clear message listing the missing columns.
+ *
+ * @param filePath  Absolute or relative path to the .xlsx / .xls file.
+ * @returns         `{ records, errors }` — valid records and per-row errors.
+ * @throws          If the file cannot be read or required columns are absent.
+ */
+export function parseXLSX(filePath: string): XLSXParseResult {
   const workbook = XLSX.readFile(filePath);
   const sheetName = workbook.SheetNames[0];
   const sheet = workbook.Sheets[sheetName];
-  const rows = XLSX.utils.sheet_to_json<XLSXRow>(sheet);
 
-  return rows.map((row) => ({
-    destination: String(row.destination || ''),
-    amount: String(row.amount || '0'),
-    asset: String(row.asset || 'XLM'),
-    asset_issuer: String(row.asset_issuer || ''),
-    memo: String(row.memo || ''),
-    escrow_duration: Number(row.escrow_duration) || 0,
-  }));
+  // Read as raw rows where headers are raw strings — normalisation happens below.
+  const rawRows = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, {
+    // Keep the raw header strings (don't sanitise) so we can normalise ourselves.
+    raw: false,
+    defval: '',
+  });
+
+  if (rawRows.length === 0) {
+    return { records: [], errors: [] };
+  }
+
+  // -------------------------------------------------------------------------
+  // Build a normalised header map: rawHeader → canonicalKey
+  // -------------------------------------------------------------------------
+  const rawHeaders = Object.keys(rawRows[0]);
+  const headerMap = buildHeaderMap(rawHeaders);
+
+  // -------------------------------------------------------------------------
+  // Validate that required columns are present in the sheet
+  // -------------------------------------------------------------------------
+  const missingRequired = REQUIRED_COLUMNS.filter((col) => !headerMap.has(col));
+  if (missingRequired.length > 0) {
+    throw new Error(
+      `XLSX file is missing required column(s): ${missingRequired.join(', ')}. ` +
+        `Found headers: ${rawHeaders.join(', ')}`,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Process each data row
+  // -------------------------------------------------------------------------
+  const records: PaymentRecord[] = [];
+  const errors: XLSXRowError[] = [];
+
+  for (let i = 0; i < rawRows.length; i++) {
+    // Row numbers are 1-based; row 1 is the header, so data starts at row 2.
+    const rowNumber = i + 2;
+    const rawRow = rawRows[i];
+
+    // Remap raw column names to canonical keys.
+    const row = remapRow(rawRow, headerMap);
+
+    // Validate and collect errors.
+    const rowErrors = validateRow(row, rowNumber);
+    if (rowErrors.length > 0) {
+      errors.push({ row: rowNumber, errors: rowErrors });
+      continue;
+    }
+
+    records.push(buildRecord(row));
+  }
+
+  return { records, errors };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Map from canonical column key → raw header string (for value lookup)
+ * by matching each raw header against HEADER_ALIASES.
+ *
+ * We store canonical→raw so that later lookups can pull the value out of the
+ * original row object using the exact raw key.
+ */
+function buildHeaderMap(rawHeaders: string[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const raw of rawHeaders) {
+    const normalised = raw.trim().toLowerCase();
+    const canonical = HEADER_ALIASES[normalised];
+    if (canonical && !map.has(canonical)) {
+      // First occurrence wins when two columns alias to the same canonical key.
+      map.set(canonical, raw);
+    }
+  }
+  return map;
+}
+
+/**
+ * Produce a plain object keyed by canonical field names from a single raw row.
+ */
+function remapRow(
+  rawRow: Record<string, unknown>,
+  headerMap: Map<string, string>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [canonical, rawHeader] of headerMap.entries()) {
+    out[canonical] = rawRow[rawHeader];
+  }
+  return out;
+}
+
+/**
+ * Validate a single (already remapped) row.  Returns an array of error
+ * messages; an empty array means the row is valid.
+ */
+function validateRow(row: Record<string, unknown>, rowNumber: number): string[] {
+  const errors: string[] = [];
+
+  // --- destination ---
+  const destination = trimString(row.destination);
+  if (!destination) {
+    errors.push(`Row ${rowNumber}: missing required field "destination"`);
+  } else if (!isNonEmptyString(destination)) {
+    errors.push(`Row ${rowNumber}: "destination" must be a non-empty string`);
+  }
+
+  // --- amount ---
+  const rawAmount = trimString(row.amount);
+  if (!rawAmount) {
+    errors.push(`Row ${rowNumber}: missing required field "amount"`);
+  } else {
+    const num = Number(rawAmount);
+    if (isNaN(num)) {
+      errors.push(`Row ${rowNumber}: "amount" is not a valid number ("${rawAmount}")`);
+    } else if (num <= 0) {
+      errors.push(`Row ${rowNumber}: "amount" must be greater than zero (got ${num})`);
+    }
+  }
+
+  // --- escrow_duration (optional but must be a non-negative integer if present) ---
+  const rawEscrow = row.escrow_duration;
+  if (rawEscrow !== undefined && rawEscrow !== '') {
+    const escrowNum = Number(rawEscrow);
+    if (isNaN(escrowNum)) {
+      errors.push(
+        `Row ${rowNumber}: "escrow_duration" is not a valid number ("${rawEscrow}") — use 0 to disable escrow`,
+      );
+    } else if (!Number.isInteger(escrowNum) || escrowNum < 0) {
+      errors.push(
+        `Row ${rowNumber}: "escrow_duration" must be a non-negative integer (got ${escrowNum})`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+/** Build a PaymentRecord from a validated, remapped row. */
+function buildRecord(row: Record<string, unknown>): PaymentRecord {
+  return {
+    destination: trimString(row.destination) ?? '',
+    amount: trimString(row.amount) ?? '0',
+    asset: trimString(row.asset) || 'XLM',
+    asset_issuer: trimString(row.asset_issuer) ?? '',
+    memo: trimString(row.memo) ?? '',
+    escrow_duration: parseEscrowDuration(row.escrow_duration),
+  };
+}
+
+/** Safely trim a value to a string, returning undefined if falsy. */
+function trimString(value: unknown): string | undefined {
+  if (value === null || value === undefined || value === '') return undefined;
+  return String(value).trim();
+}
+
+function isNonEmptyString(value: string): boolean {
+  return value.trim().length > 0;
+}
+
+function parseEscrowDuration(value: unknown): number {
+  if (value === undefined || value === null || value === '') return 0;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0;
 }


### PR DESCRIPTION
# PR: Strong validation and normalisation in JSON parser

**Closes #32**

## Summary

The JSON parser previously mapped raw input directly to `PaymentRecord` with no
validation, meaning missing fields, wrong types, or non-positive amounts would
silently produce malformed batch entries. This PR adds full schema validation,
field normalisation, and structured per-entry error reporting matching the
pattern established in the XLSX parser (#33).

## Changes

### `cli/src/parsers/json-parser.ts` (rewritten)

**Top-level schema validation**
- Accepts both a top-level array `[{...}]` and a wrapper object `{ "payments": [{...}] }`.
- Throws `TypeError` with a clear message for any other top-level shape (plain
  string, number, object without a `payments` key).
- Throws `TypeError` when the `payments` key exists but is not an array.
- Re-throws `JSON.parse` errors as `SyntaxError` with the file path included.

**Entry-level validation**
Every entry is validated before inclusion in `records`. Invalid entries are
collected in `errors` with a 1-based `index` and an array of human-readable
messages. Validated fields:

| Field | Rule |
|---|---|
| `destination` | Required, must be a non-empty string |
| `amount` | Required, must be a number greater than zero |
| `asset` | Optional; if present, must be a non-empty string |
| `asset_issuer` | Optional; if present, must be a string |
| `memo` | Optional; if present, must be a string |
| `escrow_duration` | Optional; if present, must be a non-negative integer |

**Field normalisation**
- `destination` — trimmed.
- `amount` — accepted as `string | number`; converted to trimmed string.
- `asset` — trimmed and **upper-cased** (e.g. `"usdc"` → `"USDC"`); defaults to `"XLM"` when absent.
- `asset_issuer`, `memo` — trimmed strings; default to `""` when absent.
- `escrow_duration` — must be a non-negative integer; defaults to `0` when absent.

**Return type changed**
```ts
// Before
export function parseJSON(filePath: string): PaymentRecord[]

// After
export function parseJSON(filePath: string): JSONParseResult

interface JSONParseResult {
  records: PaymentRecord[];   // entries that passed all checks
  errors: JSONEntryError[];   // entries that failed, with 1-based index + messages
}
interface JSONEntryError {
  index: number;   // 1-based position in the payments array
  errors: string[];
}
```

### `cli/src/parsers/json-parser.test.ts` (expanded)

48 tests total across 6 suites (previously 20 tests across 5 suites):

| Suite | Tests |
|---|---|
| top-level array format | 10 |
| object wrapper format | 3 |
| default values for missing optional fields | 4 |
| field normalisation | 6 |
| entry-level validation | 16 |
| top-level schema errors | 6 |
| edge cases | 3 |

New coverage includes:
- All entry-level error cases: missing/empty destination, missing/non-numeric/zero/negative amount, wrong-type asset/memo, non-numeric/negative/fractional `escrow_duration`
- Multiple errors reported for the same entry
- Correct 1-based index on every `JSONEntryError`
- Valid entries returned alongside invalid ones
- All top-level schema error cases: bare string, bare number, object without `payments`, `payments` not an array
- Asset upper-casing from lowercase and mixed-case input
- Whitespace trimming on destination, amount, and memo

## Test results

```
Test Suites: 1 passed, 1 total
Tests:       48 passed, 48 total
```
