### PR TITLE
fix(cli): resolve issues #87, #89, #90, #91 — JSON validation, batch recovery, schema validation, retry guard

### DIFF
--- a/cli/src/commands/batch.ts
+++ b/cli/src/commands/batch.ts
@@ -1,64 +1,3 @@
-import { logger } from '../utils/logger';
-
-interface BatchRecord {
-  destination: string;
-  amount: string;
-  asset?: string;
-  [key: string]: unknown;
-}
-
-interface DryRunSummary {
-  totalRows:     number;
-  validRows:     number;
-  invalidRows:   number;
-  invalidDetails: { row: number; reason: string }[];
-  estimatedCost: string;
-}
-
-function validateRecord(record: BatchRecord, index: number) {
-  const errors: string[] = [];
-  if (!record.destination) errors.push('missing destination');
-  if (!record.amount || isNaN(Number(record.amount))) errors.push('invalid amount');
-  return errors.length
-    ? { row: index + 1, reason: errors.join(', ') }
-    : null;
-}
-
-export function dryRunSummary(records: BatchRecord[]): DryRunSummary {
-  const invalidDetails: { row: number; reason: string }[] = [];
-
-  records.forEach((r, i) => {
-    const err = validateRecord(r, i);
-    if (err) invalidDetails.push(err);
-  });
-
-  const validRows = records.length - invalidDetails.length;
-
-  return {
-    totalRows:     records.length,
-    validRows,
-    invalidRows:   invalidDetails.length,
-    invalidDetails,
-    estimatedCost: `~${(validRows * 0.00001).toFixed(5)} XLM base fee`,
-  };
-}
-
-export function printDryRunReport(summary: DryRunSummary) {
-  logger.info('====== DRY-RUN SUMMARY ======');
-  logger.info(`Total rows:      ${summary.totalRows}`);
-  logger.info(`Valid rows:      ${summary.validRows}`);
-  logger.warn(`Invalid rows:    ${summary.invalidRows}`);
-  logger.info(`Estimated cost:  ${summary.estimatedCost}`);
-
-  if (summary.invalidDetails.length > 0) {
-    logger.warn('Invalid row details:');
-    summary.invalidDetails.forEach(d =>
-      logger.warn(`  Row ${d.row}: ${d.reason}`)
-    );
-  }
-  logger.info('=============================');
-}
-
 import {
   Keypair,
   Account,
@@ -153,12 +92,156 @@ function getNetworkPassphrase(network: NetworkType): string {
 export async function executeBatch(config: BatchConfig): Promise<void> {
   setupSignalHandlers();
 
-  const batchId = crypto.randomBytes(8).toString('hex');
   const db = new BatchDatabase(config.dbPath);
   currentDb = db;
-  currentBatchId = batchId;
 
   logger.banner('Stellar Payout - Batch Processor');
+
+  // ── Stale batch recovery ────────────────────────────────────────────────
+  // Detect any batches that are still marked 'paused' or 'running' in the
+  // database.  A 'paused' batch was stopped gracefully by SIGINT/SIGTERM; a
+  // 'running' batch whose process is no longer alive crashed without cleanup.
+  // Both cases are safe to resume: we restore their state to 'running',
+  // refresh counters, and reprocess only the incomplete transaction groups.
+  const staleBatches = db.getBatchesNeedingResume();
+  if (staleBatches.length > 0) {
+    logger.warn(
+      `Found ${staleBatches.length} incomplete batch(es) in the database. Resuming...`
+    );
+
+    const sourceKeypair = Keypair.fromSecret(config.sourceSecret);
+    const networkPassphrase = config.networkPassphrase || getNetworkPassphrase(config.network);
+
+    for (const staleBatch of staleBatches) {
+      logger.info(`Resuming batch ${staleBatch.batchId} (status: ${staleBatch.status})`);
+
+      // Transition status: paused/running → running, refresh counters.
+      db.resumeBatch(staleBatch.batchId);
+      currentBatchId = staleBatch.batchId;
+
+      const incompleteGroups = db.getIncompleteGroups(staleBatch.batchId);
+      if (incompleteGroups.length === 0) {
+        logger.success(`Batch ${staleBatch.batchId} has no incomplete groups — marking completed.`);
+        db.updateBatchCounters(staleBatch.batchId);
+        db.updateBatchStatus(staleBatch.batchId, BatchStatus.Completed);
+        continue;
+      }
+
+      logger.info(`Re-processing ${incompleteGroups.length} incomplete group(s)...`);
+
+      // Re-fetch a fresh sequence number before resuming group submission.
+      let resumeAllocator: SequenceAllocator;
+      try {
+        const accountResponse = await axios.get(
+          `${config.horizonUrl}/accounts/${sourceKeypair.publicKey()}`,
+          { timeout: 15000 }
+        );
+        resumeAllocator = new SequenceAllocator(accountResponse.data.sequence);
+      } catch (err) {
+        logger.error(
+          `Failed to fetch source account for resume: ${err instanceof Error ? err.message : String(err)}`
+        );
+        db.updateBatchStatus(staleBatch.batchId, BatchStatus.Failed);
+        continue;
+      }
+
+      const semaphore = new Semaphore(config.concurrency);
+      let resumedGroups = 0;
+
+      const resumePromises = incompleteGroups.map(async (group) => {
+        if (emergencyStop) return;
+        await semaphore.acquire();
+        try {
+          if (emergencyStop) return;
+
+          // Only re-submit entries that are pending/submitted; skip confirmed ones.
+          const pendingEntries = db.getPendingEntriesByGroup(
+            staleBatch.batchId,
+            group.groupIndex
+          );
+          if (pendingEntries.length === 0) {
+            logger.debug(`Group ${group.groupIndex}: all entries already confirmed, skipping.`);
+            return;
+          }
+
+          // Re-check for fee surge before re-submitting.
+          const feeCheck = await checkFeeSurge(config.horizonUrl, config.feeSurgeThreshold);
+          if (feeCheck.surging) {
+            logger.warn(`Fee surge detected (${feeCheck.currentFee} stroops). Pausing group ${group.groupIndex}...`);
+            await waitForFeeDrop(config.horizonUrl, config.feeSurgeThreshold);
+          }
+
+          // Convert pending entries back to PaymentRecord shape for processGroup.
+          const recordsToRetry: PaymentRecord[] = pendingEntries.map((e) => ({
+            destination: e.destination,
+            amount: e.amount,
+            asset: e.asset,
+            asset_issuer: e.asset_issuer,
+            memo: e.memo,
+            escrow_duration: e.escrow_duration,
+          }));
+
+          await processGroup(
+            recordsToRetry,
+            group.groupIndex,
+            staleBatch.batchId,
+            sourceKeypair,
+            config,
+            networkPassphrase,
+            db,
+            resumeAllocator
+          );
+
+          resumedGroups++;
+          logger.progress(resumedGroups, incompleteGroups.length, 'groups resumed');
+        } finally {
+          semaphore.release();
+        }
+      });
+
+      await Promise.all(resumePromises);
+
+      db.updateBatchCounters(staleBatch.batchId);
+      const resumedState = db.getBatch(staleBatch.batchId);
+
+      if (emergencyStop) {
+        db.updateBatchStatus(staleBatch.batchId, BatchStatus.Paused);
+        logger.warn(`Batch ${staleBatch.batchId} paused during resume.`);
+      } else {
+        db.updateBatchStatus(staleBatch.batchId, BatchStatus.Completed);
+        logger.success(`Batch ${staleBatch.batchId} resume complete.`);
+      }
+
+      if (resumedState) {
+        logger.table(
+          ['Metric', 'Value'],
+          [
+            ['Batch ID', staleBatch.batchId],
+            ['Successful', String(resumedState.successfulPayments)],
+            ['Failed', String(resumedState.failedPayments)],
+            ['Skipped', String(resumedState.skippedPayments)],
+          ]
+        );
+        if (resumedState.failedPayments > 0) {
+          logger.info(
+            `Retry remaining failures with: stellar-payout retry --batch-id=${staleBatch.batchId}`
+          );
+        }
+      }
+    }
+
+    if (emergencyStop) {
+      db.close();
+      currentDb = null;
+      currentBatchId = null;
+      return;
+    }
+  }
+
+  // ── New batch ────────────────────────────────────────────────────────────
+  const batchId = crypto.randomBytes(8).toString('hex');
+  currentBatchId = batchId;
+
   logger.info(`Batch ID: ${batchId}`);
   logger.info(`Input file: ${config.inputFile}`);
   logger.info(`Format: ${config.format}`);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -26,6 +26,16 @@ const DEFAULT_NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
 const DEFAULT_MAX_FEE = '10000';
 const DEFAULT_DB_PATH = './stellar-payout.db';
 
+/**
+ * Return the value of an environment variable, falling back to a built-in
+ * default when the variable is unset or empty.  Used to wire Commander option
+ * defaults so that explicit CLI flags always take precedence, then env vars,
+ * then hard-coded fallbacks.
+ */
+function envDefault(envKey: string, fallback: string): string {
+  return process.env[envKey] || fallback;
+}
+
 const program = new Command();
 
 program
@@ -145,6 +155,11 @@ program
   .option('--max-retries <number>', 'Maximum retry attempts per entry', '3')
   .option('--backoff-base <ms>', 'Base backoff delay in milliseconds', '1000')
   .option('--backoff-max <ms>', 'Maximum backoff delay in milliseconds', '30000')
+  .option(
+    '--max-total-retry-time <ms>',
+    'Total retry time budget in milliseconds — retrying stops once this wall-clock duration is exceeded, even if per-entry attempts remain. Set to 0 for no time limit.',
+    '0',
+  )
   .option('--horizon-url <url>', 'Horizon URL (or HORIZON_URL)', envDefault('HORIZON_URL', DEFAULT_HORIZON_URL))
   .option('--network-passphrase <passphrase>', 'Network passphrase (or NETWORK_PASSPHRASE)', envDefault('NETWORK_PASSPHRASE', DEFAULT_NETWORK_PASSPHRASE))
   .option('--db-path <path>', 'SQLite database path (or DB_PATH)', envDefault('DB_PATH', DEFAULT_DB_PATH))

--- a/cli/src/parsers/index.ts
+++ b/cli/src/parsers/index.ts
@@ -8,10 +8,25 @@ export function parseInputFile(filePath: string, format: InputFormat): PaymentRe
   switch (format) {
     case InputFormat.CSV:
       return parseCSV(filePath);
-    case InputFormat.JSON:
-      return parseJSON(filePath);
-    case InputFormat.XLSX:
-      return parseXLSX(filePath);
+    case InputFormat.JSON: {
+      const result = parseJSON(filePath);
+      if (result.errors.length > 0) {
+        // Surface validation errors as warnings via stderr; only valid records proceed.
+        result.errors.forEach(e =>
+          process.stderr.write(`JSON parse warning: entry ${e.index}: ${e.errors.join(', ')}\n`)
+        );
+      }
+      return result.records;
+    }
+    case InputFormat.XLSX: {
+      const result = parseXLSX(filePath);
+      if (result.errors.length > 0) {
+        result.errors.forEach(e =>
+          process.stderr.write(`XLSX parse warning: row ${e.row}: ${e.errors.join(', ')}\n`)
+        );
+      }
+      return result.records;
+    }
     case InputFormat.MT103:
       return parseMT103(filePath);
     default:

--- a/cli/src/utils/database.ts
+++ b/cli/src/utils/database.ts
@@ -253,7 +253,7 @@ export class BatchDatabase {
                skipped_payments = ?
            WHERE batch_id = ?`,
         )
-        .run(stats.processed, stats.successful, stats.failed, stats.skipped, batchId);
+        .run(stats.processed ?? 0, stats.successful ?? 0, stats.failed ?? 0, stats.skipped ?? 0, batchId);
     });
 
     refresh();
@@ -290,7 +290,7 @@ export class BatchDatabase {
                skipped_payments = ?
            WHERE batch_id = ?`,
         )
-        .run(stats.processed, stats.successful, stats.failed, stats.skipped, batchId);
+        .run(stats.processed ?? 0, stats.successful ?? 0, stats.failed ?? 0, stats.skipped ?? 0, batchId);
     });
 
     pauseAndCount();
@@ -365,7 +365,7 @@ export class BatchDatabase {
       .prepare(
         `SELECT * FROM batches
          WHERE status IN ('paused', 'running')
-         ORDER BY started_at DESC`,
+         ORDER BY started_at DESC, rowid DESC`,
       )
       .all() as Record<string, unknown>[];
     return rows.map((r) => this.rowToBatchState(r));
@@ -381,7 +381,7 @@ export class BatchDatabase {
 
   getRecentBatches(limit: number = 10): BatchState[] {
     const rows = this.db
-      .prepare('SELECT * FROM batches ORDER BY started_at DESC LIMIT ?')
+      .prepare('SELECT * FROM batches ORDER BY started_at DESC, rowid DESC LIMIT ?')
       .all(limit) as Record<string, unknown>[];
     return rows.map((r) => this.rowToBatchState(r));
   }

--- a/cli/src/utils/validation.ts
+++ b/cli/src/utils/validation.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { isValidStellarPublicKey } from '@stellar-cross-border/sdk';
+import { StrKey } from 'stellar-sdk';
 import { PaymentRecord, ValidationResult } from '../types';
 import * as logger from './logger';
 
@@ -30,7 +30,11 @@ export function validateRequiredOptions(
 }
 
 export function validateStellarAddress(address: string): boolean {
-  return isValidStellarPublicKey(address);
+  try {
+    return StrKey.isValidEd25519PublicKey(address);
+  } catch {
+    return false;
+  }
 }
 
 export async function validateDestination(
@@ -85,6 +89,26 @@ export async function validateDestination(
   return result;
 }
 
+/** Maximum memo length accepted by Stellar (text memo cap). */
+const MAX_MEMO_LENGTH = 28;
+
+/** Maximum length for a Stellar asset code (e.g. "USDC" = 4, "LONGTOKEN" = 12). */
+const MAX_ASSET_CODE_LENGTH = 12;
+
+/** Regex for valid Stellar asset codes: 1–12 alphanumeric characters. */
+const ASSET_CODE_RE = /^[A-Za-z0-9]{1,12}$/;
+
+/**
+ * Validate a full batch of payment records.
+ *
+ * Checks performed per record (in addition to on-chain destination validation):
+ * - destination: present and a valid Stellar public key (G…, 56 chars, base32)
+ * - amount: present, numeric, and greater than zero
+ * - asset: present, non-empty, 1–12 alphanumeric characters (Stellar asset code format)
+ * - asset_issuer: when present and asset is not XLM/native, must be a valid Stellar address
+ * - memo: when present, must not exceed MAX_MEMO_LENGTH (28) characters
+ * - escrow_duration: when present, must be a non-negative integer
+ */
 export async function validateBatch(
   records: PaymentRecord[],
   horizonUrl: string,
@@ -97,24 +121,55 @@ export async function validateBatch(
     const record = records[i];
     const errors: string[] = [];
 
+    // --- destination ---
     if (!record.destination) {
       errors.push('Missing destination address');
     } else if (!validateStellarAddress(record.destination)) {
       errors.push(`Invalid Stellar address: ${record.destination}`);
     }
 
+    // --- amount ---
     if (!record.amount || isNaN(Number(record.amount)) || Number(record.amount) <= 0) {
       errors.push(`Invalid amount: ${record.amount}`);
     }
 
+    // --- asset / token ---
     if (!record.asset) {
-      errors.push('Missing asset code');
+      errors.push('Missing asset code (token)');
+    } else if (!ASSET_CODE_RE.test(record.asset)) {
+      errors.push(
+        `Invalid asset code "${record.asset}": must be 1–${MAX_ASSET_CODE_LENGTH} alphanumeric characters`
+      );
     }
 
-    if (record.escrow_duration !== undefined && record.escrow_duration < 0) {
-      errors.push(`Invalid escrow duration: ${record.escrow_duration}`);
+    // --- asset_issuer (required for non-native assets) ---
+    const isNativeAsset =
+      !record.asset ||
+      record.asset.toUpperCase() === 'XLM' ||
+      record.asset.toLowerCase() === 'native';
+    if (!isNativeAsset && record.asset_issuer) {
+      if (!validateStellarAddress(record.asset_issuer)) {
+        errors.push(`Invalid asset issuer address: ${record.asset_issuer}`);
+      }
     }
 
+    // --- memo length ---
+    if (record.memo && record.memo.length > MAX_MEMO_LENGTH) {
+      errors.push(
+        `Memo too long: ${record.memo.length} characters (max ${MAX_MEMO_LENGTH})`
+      );
+    }
+
+    // --- escrow_duration ---
+    if (record.escrow_duration !== undefined) {
+      if (!Number.isInteger(record.escrow_duration) || record.escrow_duration < 0) {
+        errors.push(
+          `Invalid escrow duration: ${record.escrow_duration} — must be a non-negative integer (seconds)`
+        );
+      }
+    }
+
+    // --- on-chain destination/trustline check ---
     if (!skipAddressCheck && errors.length === 0) {
       const validation = await validateDestination(record.destination, record.asset, horizonUrl);
       if (!validation.valid) {


### PR DESCRIPTION
## Summary

Fixes four CLI issues in a single commit from a fork branch.

---

### #87 — Fix CLI JSON parser to validate payment input structure

Closes #87

The JSON parser now validates every entry before accepting it:
- `destination` and `amount` are required and non-empty
- `amount` must be a positive number
- `asset` must be a 1–12 alphanumeric string when provided
- `asset_issuer` must be a string when provided
- `memo` must be a string when provided
- `escrow_duration` must be a non-negative integer when provided

Invalid entries are collected in `JSONParseResult.errors` with 1-based index and human-readable messages; valid records continue to `records`. `parsers/index.ts` updated to unwrap `JSONParseResult`/`XLSXParseResult` and surface parse warnings.

---

### #89 — Improve CLI batch recovery when processing fails mid-run

Closes #89

`executeBatch()` now detects stale batches at startup:
- Calls `getBatchesNeedingResume()` to find `paused` (graceful SIGINT) and `running` (hard crash) batches in the database
- For each stale batch: `resumeBatch()` transitions status → `running` and refreshes counters; `getIncompleteGroups()` + `getPendingEntriesByGroup()` identify exactly which work remains; only incomplete groups are re-submitted, confirmed groups are skipped
- Fetches a fresh sequence number before re-submitting to avoid `tx_bad_seq` errors

---

### #90 — Add CLI batch input schema validation before transaction submission

Closes #90

`validateBatch()` added to `validation.ts` with per-record checks before any transaction is built:
- `destination`: valid Stellar public key (G…, 56 chars)
- `amount`: present and > 0
- `asset`: 1–12 alphanumeric characters
- `asset_issuer`: valid Stellar address when present for non-native assets
- `memo`: ≤ 28 characters
- `escrow_duration`: non-negative integer

---

### #91 — Fix CLI retry command to guard against infinite retry loops

Closes #91

- `isRetryTimeBudgetExhausted()` helper in `utils/retry-budget.ts` implements a wall-clock time limit
- `--max-total-retry-time <ms>` option added to the `retry` command (0 = no limit, preserving original behaviour)
- `executeRetry()` breaks the loop when elapsed time exceeds the budget, even if per-entry attempts remain
- `envDefault()` helper added to `index.ts` so all option defaults correctly resolve env-var overrides

---

## Additional fixes (pre-existing compile errors)

- Removed orphaned dry-run code block from `batch.ts` (caused duplicate `logger` identifier error)
- Fixed broken `@stellar-cross-border/sdk` import in `validation.ts` — replaced with direct `StrKey` from `stellar-sdk`
- Fixed NULL SUM bug in `database.ts` `markBatchPaused`/`updateBatchCounters` — SQLite `SUM()` over an empty set returns `NULL`, violating the `NOT NULL` constraint; fixed with `?? 0` nullish coalescing
- Added `rowid` tiebreaker to `getRecentBatches`/`getBatchesNeedingResume` for deterministic ordering when `started_at` timestamps are equal

## Testing

All **199 tests** pass (`npx jest --no-coverage` in `cli/`).
TypeScript compiles cleanly with `npx tsc --noEmit`.