### PR TITLE
fix: resolve issues #97, #95, #94, #92 (BashMan11)

### DIFF
--- a/cli/src/commands/batch.ts
+++ b/cli/src/commands/batch.ts
@@ -153,6 +153,43 @@ function getNetworkPassphrase(network: NetworkType): string {
 export async function executeBatch(config: BatchConfig): Promise<void> {
   setupSignalHandlers();
 
+  // --- #94: Validate source secret and account existence before doing anything ---
+  // Fail fast here so the operator sees a clear error before any DB state is
+  // written or any payment records are parsed.
+  let sourceKeypair: Keypair;
+  try {
+    sourceKeypair = Keypair.fromSecret(config.sourceSecret);
+  } catch {
+    logger.error(
+      'Invalid source secret key. Ensure --source-secret (or ADMIN_SECRET_KEY) is a valid Stellar secret key (starts with "S").'
+    );
+    return;
+  }
+
+  const sourcePublicKey = sourceKeypair.publicKey();
+
+  if (!config.dryRun) {
+    logger.info(`Validating source account ${sourcePublicKey} on ${config.network}...`);
+    try {
+      await axios.get(`${config.horizonUrl}/accounts/${sourcePublicKey}`, { timeout: 15000 });
+      logger.success('Source account validated.');
+    } catch (err: any) {
+      if (err.response?.status === 404) {
+        logger.error(
+          `Source account ${sourcePublicKey} does not exist on ${config.network}. ` +
+          'Fund the account before running a batch.'
+        );
+      } else {
+        logger.error(
+          `Could not reach Horizon at ${config.horizonUrl} to validate source account: ` +
+          (err.message ?? String(err))
+        );
+      }
+      return;
+    }
+  }
+  // --- end #94 ---
+
   const batchId = crypto.randomBytes(8).toString('hex');
   const db = new BatchDatabase(config.dbPath);
   currentDb = db;
@@ -208,9 +245,7 @@ export async function executeBatch(config: BatchConfig): Promise<void> {
 
   logger.success(`${valid.length} valid payments ready for processing`);
 
-  // Load source keypair
-  const sourceKeypair = Keypair.fromSecret(config.sourceSecret);
-  const sourcePublicKey = sourceKeypair.publicKey();
+  // sourceKeypair and sourcePublicKey are already validated at the top of executeBatch
   logger.info(`Source account: ${sourcePublicKey}`);
 
   // Create batch in database — atomically creates the row and sets status to

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -154,47 +154,102 @@ async function streamBatchProgress(db: BatchDatabase, options: StatusStreamOptio
   // Also stream from Horizon if a source account is available
   const batch = db.getBatch(options.batchId);
   if (batch?.sourceAccount) {
-    try {
-      const streamUrl = `${options.horizonUrl}/accounts/${batch.sourceAccount}/transactions?cursor=now&order=asc&limit=1`;
-      logger.debug(`Horizon stream endpoint: ${streamUrl}`);
+    const sourceAccount = batch.sourceAccount; // capture to avoid null checks inside callbacks
+    // --- #92: Disconnect-resilient Horizon polling ---
+    // Track consecutive failures so we can log reconnect attempts and apply
+    // exponential backoff instead of hammering a temporarily unreachable node.
+    const MAX_CONSECUTIVE_FAILURES = 5;
+    const BASE_BACKOFF_MS = 1000;
+    const MAX_BACKOFF_MS = 30000;
+    const POLL_INTERVAL_MS = 5000;
 
-      // Poll Horizon for new transactions
-      let lastPagingToken = 'now';
-      const pollInterval = setInterval(async () => {
-        const currentBatch = db.getBatch(options.batchId);
-        if (!currentBatch || currentBatch.status !== BatchStatus.Running) {
-          clearInterval(pollInterval);
+    let lastPagingToken = 'now';
+    let consecutiveFailures = 0;
+    let reconnectBackoff = BASE_BACKOFF_MS;
+    let pollTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+    const streamUrl = `${options.horizonUrl}/accounts/${sourceAccount}/transactions?cursor=now&order=asc&limit=1`;
+    if (options.verbose) {
+      logger.debug(`Horizon stream endpoint: ${streamUrl}`);
+    }
+
+    /** Schedule the next Horizon poll after `delay` ms. */
+    function scheduleNextPoll(delay: number): void {
+      pollTimeoutHandle = setTimeout(pollHorizon, delay);
+    }
+
+    async function pollHorizon(): Promise<void> {
+      const currentBatch = db.getBatch(options.batchId);
+      if (!currentBatch || currentBatch.status !== BatchStatus.Running) {
+        // Batch finished — stop the Horizon tail.
+        return;
+      }
+
+      try {
+        const response = await axios.get(
+          `${options.horizonUrl}/accounts/${sourceAccount}/transactions`,
+          {
+            params: { cursor: lastPagingToken, order: 'asc', limit: 10 },
+            timeout: 10000,
+          }
+        );
+
+        const txRecords = response.data._embedded?.records || [];
+        for (const tx of txRecords) {
+          logger.info(`  New tx: ${tx.hash} (${tx.operation_count} ops) - ${tx.successful ? 'OK' : 'FAILED'}`);
+          lastPagingToken = tx.paging_token;
+        }
+
+        // Successful response — reset failure counters.
+        if (consecutiveFailures > 0) {
+          logger.info('  Horizon connection restored.');
+          consecutiveFailures = 0;
+          reconnectBackoff = BASE_BACKOFF_MS;
+        }
+
+        scheduleNextPoll(POLL_INTERVAL_MS);
+      } catch (err: any) {
+        consecutiveFailures++;
+        const reason = err?.response
+          ? `HTTP ${err.response.status}`
+          : (err?.message ?? 'unknown error');
+
+        if (consecutiveFailures === 1) {
+          logger.warn(`  Horizon poll failed (${reason}). Retrying with backoff...`);
+        } else {
+          logger.warn(
+            `  Horizon still unreachable after ${consecutiveFailures} attempts (${reason}). ` +
+            `Next retry in ${reconnectBackoff / 1000}s...`
+          );
+        }
+
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+          logger.warn(
+            `  Horizon has been unreachable for ${consecutiveFailures} consecutive attempts. ` +
+            'DB progress monitoring continues. Re-run with --follow once Horizon recovers.'
+          );
+          // Stop the Horizon tail — the DB interval already covers progress.
           return;
         }
 
-        try {
-          const response = await axios.get(
-            `${options.horizonUrl}/accounts/${batch.sourceAccount}/transactions`,
-            {
-              params: { cursor: lastPagingToken, order: 'asc', limit: 10 },
-              timeout: 10000,
-            }
-          );
-
-          const txRecords = response.data._embedded?.records || [];
-          for (const tx of txRecords) {
-            logger.info(`  New tx: ${tx.hash} (${tx.operation_count} ops) - ${tx.successful ? 'OK' : 'FAILED'}`);
-            lastPagingToken = tx.paging_token;
-          }
-        } catch {
-          // Ignore stream errors
-        }
-      }, 5000);
-
-      // Cleanup on process exit
-      process.on('SIGINT', () => {
-        clearInterval(checkInterval);
-        clearInterval(pollInterval);
-        process.exit(0);
-      });
-    } catch {
-      // Stream not available, continue with interval-based monitoring
+        // Exponential backoff capped at MAX_BACKOFF_MS.
+        scheduleNextPoll(reconnectBackoff);
+        reconnectBackoff = Math.min(reconnectBackoff * 2, MAX_BACKOFF_MS);
+      }
     }
+
+    // Kick off the first poll.
+    scheduleNextPoll(POLL_INTERVAL_MS);
+
+    // Cleanup all timers on SIGINT.
+    process.on('SIGINT', () => {
+      clearInterval(checkInterval);
+      if (pollTimeoutHandle !== null) {
+        clearTimeout(pollTimeoutHandle);
+      }
+      process.exit(0);
+    });
+    // --- end #92 ---
   }
 
   // Wait for batch to complete or user to cancel

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -133,6 +133,7 @@ program
       follow: opts.follow,
       dbPath: opts.dbPath,
       horizonUrl: opts.horizonUrl,
+      verbose: opts.verbose,
     });
   });
 

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -103,6 +103,7 @@ export interface StatusStreamOptions {
   follow: boolean;
   dbPath: string;
   horizonUrl: string;
+  verbose?: boolean;
 }
 
 export interface RetryOptions {

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -67,16 +67,21 @@ export class StellarClient {
       const response = await this.httpClient.get(`/accounts/${accountId}`);
       const account = response.data;
 
+      // Defensively handle ledgers where balances or flags may be absent
+      const balances: any[] = Array.isArray(account.balances) ? account.balances : [];
+      const nativeEntry = balances.find((b: any) => b.asset_type === 'native');
+      const flags = account.flags ?? {};
+
       return {
         accountId: account.id,
-        balance:
-          account.balances.find((b: any) => b.asset_type === 'native')?.balance ?? '0',
+        // Fall back to '0' when no native (XLM) balance entry is present
+        balance: nativeEntry?.balance ?? '0',
         sequence: account.sequence,
-        numSubentries: account.num_subentries,
+        numSubentries: account.num_subentries ?? 0,
         flags: {
-          authRequired: account.flags.auth_required,
-          authRevocable: account.flags.auth_revocable,
-          authImmutable: account.flags.auth_immutable,
+          authRequired: flags.auth_required ?? false,
+          authRevocable: flags.auth_revocable ?? false,
+          authImmutable: flags.auth_immutable ?? false,
         },
       };
     } catch (error) {
@@ -124,12 +129,22 @@ export class StellarClient {
     } = {}
   ): Promise<TransactionBuilder> {
     const fee = options.fee ?? (options.feeBump ? '2000' : BASE_FEE);
-    const timeout = options.timeout ?? TimeoutInfinite;
+    const timeoutSeconds = options.timeout ?? TimeoutInfinite;
+
+    // Convert a relative timeout (seconds) into an absolute Unix maxTime.
+    // TimeoutInfinite (0) means no expiry — pass 0 to disable the upper bound.
+    // Any positive value is treated as seconds-from-now, which is the correct
+    // semantics for transaction timebounds: minTime=0 (valid immediately),
+    // maxTime=<absolute unix timestamp> (expires after N seconds).
+    const maxTime =
+      timeoutSeconds === TimeoutInfinite || timeoutSeconds === 0
+        ? TimeoutInfinite
+        : Math.floor(Date.now() / 1000) + timeoutSeconds;
 
     let builder = new TransactionBuilder(sourceAccount, {
       fee,
       networkPassphrase: this.config.networkPassphrase,
-      timebounds: { minTime: 0, maxTime: timeout },
+      timebounds: { minTime: 0, maxTime },
     });
 
     if (options.memo) {


### PR DESCRIPTION
## Summary

Fixes four issues assigned to @BashMan11 in a single atomic commit.

---

### Fix #97 — `getAccount` native balance extraction when missing

**Problem:** `getAccount` accessed `account.balances.find()` and `account.flags.auth_required` directly. On unusual ledgers (newly-funded accounts, stripped test accounts) the `balances` array or `flags` object may be absent, causing a `TypeError`.

**Fix:** Defensively normalise the response — fall back to an empty array for `balances` and an empty object for `flags`. The native balance entry falls through to the existing `?? '0'` guard; all flag booleans default to `false`.

---

### Fix #95 — `buildTransaction` proper timebounds semantics

**Problem:** `timeout` (a relative duration in seconds) was passed directly as `maxTime` to the `TransactionBuilder`. Stellar timebounds require an *absolute* Unix timestamp for `maxTime`. Passing e.g. `30` as `maxTime` results in a timebound set to 30 seconds after the epoch (1970), which is always already expired.

**Fix:** Convert the relative timeout to an absolute Unix timestamp: `maxTime = Math.floor(Date.now() / 1000) + timeoutSeconds`. `TimeoutInfinite` (0) is still treated as no upper bound.

---

### Fix #94 — CLI source secret validation before batch execution

**Problem:** The source secret key and account existence were validated late in `executeBatch`, after the input file was parsed. An invalid key or non-existent account would waste I/O and produce a confusing error mid-batch.

**Fix:** Move secret validation to the very top of `executeBatch`:
1. Parse the keypair immediately — fail fast with a clear message if the format is wrong.
2. In non-dry-run mode, verify the account exists on Horizon before proceeding.

The duplicate `Keypair.fromSecret` call later in the function has been removed.

---

### Fix #92 — CLI status streaming disconnect handling and recovery

**Problem:** The Horizon polling loop inside `streamBatchProgress` silently swallowed all errors (`catch {}`). A transient Horizon outage would cause the tail to appear frozen, and the loop would continue hammering the unreachable node at full speed.

**Fix:** Replaced the `setInterval`-based Horizon poller with a resilient recursive `setTimeout` poller that:
- Tracks consecutive failures and logs a warning on the first failure.
- Applies exponential backoff (1s to 30s, capped) between retries.
- Stops automatically after 5 consecutive failures with a recovery hint.
- Logs a "connection restored" message when Horizon becomes reachable again.
- Cleans up the timer handle on SIGINT.

`verbose?: boolean` was added to `StatusStreamOptions` and wired through from the `--verbose` flag so the Horizon stream URL is printed in debug mode.

---

Closes #97
Closes #95
Closes #94
Closes #92
