### PR TITLE
fix(cli): case-insensitive batch format detection for uppercase extensions

### DIFF
--- a/cli/src/parsers/detectFormat.test.ts
+++ b/cli/src/parsers/detectFormat.test.ts
@@ -47,4 +47,24 @@ describe('detectFormat — case-insensitive file extension detection', () => {
   test('defaults to CSV for an unknown extension', () => {
     expect(detectFormat('file.unknown')).toBe(InputFormat.CSV);
   });
+
+  // Edge cases
+  test('handles multiple dots in filename', () => {
+    expect(detectFormat('data.payments.csv')).toBe(InputFormat.CSV);
+  });
+  test('handles file without extension', () => {
+    expect(detectFormat('README')).toBe(InputFormat.CSV);
+  });
+  test('handles just an extension string', () => {
+    expect(detectFormat('.json')).toBe(InputFormat.JSON);
+  });
+  test('handles empty string', () => {
+    expect(detectFormat('')).toBe(InputFormat.CSV);
+  });
+  test('handles XLSX with mixed case', () => {
+    expect(detectFormat('report.XlSx')).toBe(InputFormat.XLSX);
+  });
+  test('handles SWIFT extension with mixed case', () => {
+    expect(detectFormat('wire.Swift')).toBe(InputFormat.MT103);
+  });
 });


### PR DESCRIPTION
Closes #85

Adds comprehensive edge-case tests for \detectFormat\ to ensure robust handling of uppercase and mixed-case file extensions (e.g., \.CSV\, \.XlSx\, \.SwIfT\).

The core fix (normalizing with \.toLowerCase()\) was already in place in \cli/src/parsers/index.ts\. This PR adds additional test coverage for edge cases:
- Multiple dots in filename (\data.payments.csv\)
- File without extension (\README\)
- Extension-only input (\.json\)
- Empty string
- Mixed-case extensions (\.XlSx\, \.SwIfT\)