### PR TITLE
feat: expand payment metadata to support primitive types and add vali…

### DIFF
--- a/sdk/src/payments.test.ts
+++ b/sdk/src/payments.test.ts
@@ -1,6 +1,7 @@
 import {
   metadataToScVal, scValToMetadata,
   toScValAddress, toScValOption,
+  StellarPayments,
 } from './payments';
 
 test('converts flat metadata to SCVal map and back', () => {
@@ -28,4 +29,53 @@ test('toScValOption wraps a value in Some', () => {
   const inner = toScValOption(null); // void as placeholder
   const opt   = toScValOption(inner);
   expect(opt.switch().name).toBe('scvVec');
+});
+
+test('convertMetadataToScVal handles empty, optional, and different types', () => {
+  const payments = new StellarPayments(null as any);
+  
+  // 1. Empty/missing metadata
+  const emptyVal1 = (payments as any).convertMetadataToScVal();
+  const emptyVal2 = (payments as any).convertMetadataToScVal({});
+  const emptyVal3 = (payments as any).convertMetadataToScVal(null as any);
+  
+  expect(emptyVal1.switch().name).toBe('scvMap');
+  expect(emptyVal1.map() || []).toHaveLength(0);
+  expect(emptyVal2.map() || []).toHaveLength(0);
+  expect(emptyVal3.map() || []).toHaveLength(0);
+
+  // 2. Optional keys (null/undefined) and different types
+  const data = {
+    strKey: 'hello',
+    numKey: 42,
+    bigKey: 100n,
+    boolKey: true,
+    bytesKey: new Uint8Array([1, 2, 3]),
+    optNull: null,
+    optUndef: undefined,
+  };
+
+  const scVal = (payments as any).convertMetadataToScVal(data);
+  expect(scVal.switch().name).toBe('scvMap');
+  
+  const entries = scVal.map() || [];
+  expect(entries).toHaveLength(5); // strKey, numKey, bigKey, boolKey, bytesKey (optNull and optUndef are omitted)
+
+  const findEntry = (key: string) => entries.find(e => e.key().sym().toString() === key);
+  
+  expect(findEntry('optNull')).toBeUndefined();
+  expect(findEntry('optUndef')).toBeUndefined();
+
+  expect(findEntry('strKey')?.val().bytes().toString()).toBe(Buffer.from('hello').toString());
+  expect(findEntry('numKey')?.val().bytes().toString()).toBe(Buffer.from('42').toString());
+  expect(findEntry('bigKey')?.val().bytes().toString()).toBe(Buffer.from('100').toString());
+  expect(findEntry('boolKey')?.val().bytes().toString()).toBe(Buffer.from('true').toString());
+  expect(findEntry('bytesKey')?.val().bytes().toString()).toBe(Buffer.from([1, 2, 3]).toString());
+});
+
+test('convertMetadataToScVal throws on unsupported types', () => {
+  const payments = new StellarPayments(null as any);
+  expect(() => {
+    (payments as any).convertMetadataToScVal({ bad: { nested: 1 } });
+  }).toThrow('unsupported value type');
 });

--- a/sdk/src/payments.ts
+++ b/sdk/src/payments.ts
@@ -548,13 +548,42 @@ export class StellarPayments {
     return new Account(accountId, accountInfo.sequence);
   }
 
-  private convertMetadataToScVal(metadata: Record<string, Uint8Array>): xdr.ScVal {
-    const entries = Object.entries(metadata).map(([key, value]) =>
-      new xdr.ScMapEntry({
-        key: xdr.ScVal.scvSymbol(key),
-        val: xdr.ScVal.scvBytes(Buffer.from(value)),
-      })
-    );
+  private convertMetadataToScVal(
+    metadata?: Record<string, Uint8Array | string | number | boolean | null | undefined>
+  ): xdr.ScVal {
+    if (!metadata || typeof metadata !== 'object') {
+      return xdr.ScVal.scvMap([]);
+    }
+
+    const entries: xdr.ScMapEntry[] = [];
+    for (const [key, value] of Object.entries(metadata)) {
+      if (value === null || value === undefined) {
+        continue;
+      }
+
+      let valScVal: xdr.ScVal;
+      if (value instanceof Uint8Array || Buffer.isBuffer(value)) {
+        valScVal = xdr.ScVal.scvBytes(Buffer.from(value));
+      } else if (typeof value === 'string') {
+        valScVal = xdr.ScVal.scvBytes(Buffer.from(value, 'utf8'));
+      } else if (typeof value === 'number' || typeof value === 'bigint') {
+        valScVal = xdr.ScVal.scvBytes(Buffer.from(value.toString(), 'utf8'));
+      } else if (typeof value === 'boolean') {
+        valScVal = xdr.ScVal.scvBytes(Buffer.from(value ? 'true' : 'false', 'utf8'));
+      } else {
+        throw new Error(
+          `Metadata key "${key}": unsupported value type "${typeof value}".`
+        );
+      }
+
+      entries.push(
+        new xdr.ScMapEntry({
+          key: xdr.ScVal.scvSymbol(key),
+          val: valScVal,
+        })
+      );
+    }
+
     return xdr.ScVal.scvMap(entries);
   }
 

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -128,7 +128,7 @@ export interface PaymentRequest {
   amount: string;
   token: string;
   release_time?: number;
-  metadata?: Record<string, Uint8Array>;
+  metadata?: Record<string, Uint8Array | string | number | boolean | null | undefined>;
 }
 
 export interface PaymentOptions {


### PR DESCRIPTION
closes #99 

# Description

This PR resolves issue #99 by improving metadata handling in `StellarPayments.createPayment` to support optional keys and different value types, ensuring empty or partially-empty metadata payloads do not cause serialization errors or invalid contract invocations.

## Changes

### 1. Type Improvements
* **[types.ts](file:///home/zakayola/Open-Source-Contribution/Drips-Contribution/stellar-cross-border-payments-sdk/sdk/src/types.ts)**:
  * Updated `PaymentRequest.metadata` to accept `Record<string, Uint8Array | string | number | boolean | null | undefined>` instead of strictly requiring `Uint8Array` values.

### 2. Converter Optimization
* **[payments.ts](file:///home/zakayola/Open-Source-Contribution/Drips-Contribution/stellar-cross-border-payments-sdk/sdk/src/payments.ts)**:
  * Safely handles empty, `null`, or `undefined` metadata inputs, reverting to a valid empty map payload (`xdr.ScVal.scvMap([])`).
  * Omit/ignore optional keys whose values are `null` or `undefined`.
  * Convert values of type `string`, `number`, `bigint`, and `boolean` dynamically to `xdr.ScVal.scvBytes` representation, making them compatible with the escrow contract's expected `Map<Symbol, Vec<u8>>` type.
  * Added validation throwing an explicit error when unsupported value types are passed.

### 3. Unit Tests
* **[payments.test.ts](file:///home/zakayola/Open-Source-Contribution/Drips-Contribution/stellar-cross-border-payments-sdk/sdk/src/payments.test.ts)**:
  * Added unit test suite verifying `convertMetadataToScVal` handles empty metadata, optional keys (`null`/`undefined`), different value types (string, number, boolean, bigint, bytes), and correctly throws on invalid nested types.
